### PR TITLE
fix: suppress FB in-app browser Java bridge Sentry noise; bump to 2.2.1 / 3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - MCP (Model Context Protocol) server (`mcp/`) with 7 tools for AI agent integration: `search_laws`, `get_random_law`, `get_law_of_the_day`, `get_law`, `list_categories`, `get_laws_by_category`, `submit_law`
-- MCP server published to npm as `murphys-laws-mcp` — install with `npx murphys-laws-mcp` (no clone needed)
+- MCP server published to npm as `murphys-laws-mcp` - install with `npx murphys-laws-mcp` (no clone needed)
 - MCP server submitted to the [MCP Registry](https://registry.modelcontextprotocol.io) for discovery by AI hosts
 - `/developers` page on the website with REST API docs, MCP setup, feeds, and machine-readable resources
 - `llms-full.txt` with detailed API docs, example responses, all 55 category slugs, and MCP setup instructions
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `ship` skill: step-by-step end-of-change workflow (version bump, CHANGELOG, rebase, commit, push, PR)
 
 ### Fixed
+- Suppress Sentry noise from Android WebView JS-to-Java bridge teardown (`Error invoking enableDidUserTypeOnKeyboardLogging: Java object is gone`). Fired on `beforeunload` inside the Facebook in-app browser when its injected keyboard-logging bridge's Java object has already been GC'd. Not our code, not actionable. Pattern `/Java object is gone/i` also covers equivalent teardown races in other Android in-app browsers.
 - Fix jsdom 28 ESM breakage: added `html-encoding-sniffer` override to 4.0.0 (the `@exodus/bytes` transitive dep is ESM-only, breaking vitest's jsdom environment)
 - Fix flaky rate-limit test: replaced `vi.advanceTimersByTime` (hung due to module-level `setInterval`) with `vi.setSystemTime`; added `afterEach` cleanup
 - Fix high-severity `serialize-javascript` vulnerability (GHSA-5c6j-r48x-rmvq, GHSA-qj8w-gfj5-8c6v): upgraded `vite-plugin-pwa` to `^1.0.0` (adds vite@7 support, removes need for `legacy-peer-deps`), added npm `overrides` to force `serialize-javascript@7.0.5` throughout the tree

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.1.3",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murphys-laws-monorepo",
-      "version": "2.1.3",
+      "version": "2.2.1",
       "license": "CC0-1.0",
       "workspaces": [
         "backend",
@@ -14372,7 +14372,7 @@
     },
     "web": {
       "name": "murphys-laws-web",
-      "version": "3.1.37",
+      "version": "3.2.1",
       "license": "CC0-1.0",
       "dependencies": {
         "@sentry/browser": "^10.25.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Murphy's Laws - Monorepo for Web, iOS, and Android apps",
   "private": true,
   "workspaces": [

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-web",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Murphy's Laws Web Application",
   "type": "module",
   "scripts": {

--- a/web/src/utils/sentry-ignore-patterns.ts
+++ b/web/src/utils/sentry-ignore-patterns.ts
@@ -17,6 +17,9 @@ export const SENTRY_IGNORED_ERROR_PATTERNS: RegExp[] = [
   /Non-Error promise rejection captured with value: undefined/i,
   // iOS WebKit bridge probe by ad/analytics scripts (e.g. Google FundingChoices) in non-native browsers
   /window\.webkit\.messageHandlers/i,
+  // Android WebView JS-to-Java bridge teardown race on beforeunload (seen in Facebook in-app
+  // browser calling its internal enableDidUserTypeOnKeyboardLogging analytics). Not our code.
+  /Java object is gone/i,
 ];
 
 /**

--- a/web/tests/sentry-ignore-patterns.test.ts
+++ b/web/tests/sentry-ignore-patterns.test.ts
@@ -13,6 +13,11 @@ describe('sentry-ignore-patterns', () => {
       expect(isSentryErrorIgnored("undefined is not an object (evaluating 'window.webkit.messageHandlers')")).toBe(true);
     });
 
+    it('returns true for Android WebView JS-to-Java bridge teardown errors (e.g. Facebook in-app browser)', () => {
+      expect(isSentryErrorIgnored('Error invoking enableDidUserTypeOnKeyboardLogging: Java object is gone')).toBe(true);
+      expect(isSentryErrorIgnored('Error invoking someMethod: Java object is gone')).toBe(true);
+    });
+
     it('returns true for Sentry SDK internal pageObserver error', () => {
       expect(isSentryErrorIgnored("feature named `pageObserver` was not found")).toBe(true);
       expect(isSentryErrorIgnored("feature named 'pageObserver' was not found")).toBe(true);
@@ -33,7 +38,7 @@ describe('sentry-ignore-patterns', () => {
 
   describe('SENTRY_IGNORED_ERROR_PATTERNS', () => {
     it('has the expected number of patterns', () => {
-      expect(SENTRY_IGNORED_ERROR_PATTERNS.length).toBe(8);
+      expect(SENTRY_IGNORED_ERROR_PATTERNS.length).toBe(9);
       expect(SENTRY_IGNORED_ERROR_PATTERNS.some((p) => p.test('chrome-extension://x'))).toBe(true);
     });
   });


### PR DESCRIPTION
## Summary

- Silence the `Error invoking enableDidUserTypeOnKeyboardLogging: Java object is gone` error firing from the Facebook in-app browser on Android during `beforeunload`. It's Facebook's injected `@JavascriptInterface` calling into a Java object that's already been GC'd by the Chromium WebView. Not our code, not actionable, and the Sentry stack contains only `<anonymous>` frames + `sentryWrapped`.
- Add `/Java object is gone/i` to `SENTRY_IGNORED_ERROR_PATTERNS`. The pattern matches the canonical Chromium WebView JS-to-Java bridge teardown string, so it also covers equivalent races in other Android in-app browsers (Instagram, LINE, TikTok, etc.) without being broad enough to swallow real app errors.
- Bump root to `2.2.1` and `web` to `3.2.1`; CHANGELOG entry under `[Unreleased] > Fixed`.

Example Sentry event this filters:
- Browser: `Facebook 556.1.0`, UA contains `FB_IAB/FB4A`
- Mechanism: `auto.browser.browserapierrors.addEventListener`
- Event type in args: `beforeunload`

## Test plan

- [x] `tests/sentry-ignore-patterns.test.ts` — 7/7 passing including the new FB IAB case
- [x] Backend unit+coverage: 352 tests pass, 98.83% statements
- [x] Web unit+coverage: 2583 tests pass, 98.58% statements (thresholds met)
- [x] Web E2E (Playwright): 18/18 passing
- [x] Typecheck + lint clean
- [x] After merge: confirm in Sentry that the `Java object is gone` issue stops receiving new events

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ravidorr/murphys-laws/71)
<!-- Reviewable:end -->
