### PR TITLE
chore: bump AGP 9.1.0 -> 9.1.1; gitignore nested xcuserdata; bump to 2.2.2 / 3.2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ ios/DerivedData/
 ios/build/
 ios/*.xcworkspace/xcuserdata/
 ios/*.xcodeproj/xcuserdata/
+ios/*.xcodeproj/project.xcworkspace/xcuserdata/
 ios/*.xcodeproj/project.xcworkspace/xcshareddata/
 ios/Pods/
 ios/.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MCP section in `llms.txt` linking to full reference and listing available tools
 
 ### Changed
+- Bump Android Gradle Plugin from `9.1.0` to `9.1.1` (patch update); add `ios/*.xcodeproj/project.xcworkspace/xcuserdata/` to `.gitignore` so Xcode's per-user IDE state stops showing up as a diff
 - MCP server rewritten to use the public REST API instead of direct SQLite access, making it fully standalone and publishable to npm
 - Track `.claude/` project config in git (`settings.json`, `launch.json`, `skills/`); exclude ephemeral paths (`worktrees/`, `settings.local.json`, `memory/`)
 - Add `ship` skill: step-by-step end-of-change workflow (version bump, CHANGELOG, rebase, commit, push, PR)

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -6,7 +6,7 @@
 // by Google in a future AGP release before Gradle 10. Safe to ignore.
 
 plugins {
-    id("com.android.application") version "9.1.0" apply false
+    id("com.android.application") version "9.1.1" apply false
     id("org.jetbrains.kotlin.android") version "2.2.21" apply false
     id("org.jetbrains.kotlin.plugin.compose") version "2.2.21" apply false
     id("com.google.dagger.hilt.android") version "2.57.2" apply false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murphys-laws-monorepo",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "CC0-1.0",
       "workspaces": [
         "backend",
@@ -14372,7 +14372,7 @@
     },
     "web": {
       "name": "murphys-laws-web",
-      "version": "3.2.1",
+      "version": "3.2.2",
       "license": "CC0-1.0",
       "dependencies": {
         "@sentry/browser": "^10.25.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Murphy's Laws - Monorepo for Web, iOS, and Android apps",
   "private": true,
   "workspaces": [

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-web",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Murphy's Laws Web Application",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Patch update of the Android Gradle Plugin in `android/build.gradle.kts`: `9.1.0` -> `9.1.1`.
- Add `ios/*.xcodeproj/project.xcworkspace/xcuserdata/` to `.gitignore`. The existing `ios/*.xcworkspace/xcuserdata/` and `ios/*.xcodeproj/xcuserdata/` entries don't cover the nested `project.xcworkspace` path where Xcode writes `UserInterfaceState.xcuserstate`, so this file was re-appearing as an uncommitted diff every time the project was opened.
- Version bumps: root `2.2.0` -> `2.2.2`, web `3.2.0` -> `3.2.2`. Skipped `2.2.1/3.2.1` because PR #71 is already claiming those.

## Test plan

- [x] Full backend + web unit suites via pre-commit hook (352 + 2583 tests pass, coverage thresholds met)
- [x] Web E2E (Playwright): 18/18 passing
- [x] Typecheck + lint clean
- [x] No `SKIP_*` env vars, `--no-verify`, or other bypass used anywhere
- [ ] After merge: confirm an Xcode open+close cycle no longer dirties the working tree
- [ ] After merge: sanity-build the Android app to confirm AGP 9.1.1 works

## Notes

- Coordinates with #71 (Sentry FB IAB filter, 2.2.1 / 3.2.1). Whichever merges first, the other will rebase cleanly on the version bump lines (only `package.json`, `web/package.json`, and `package-lock.json` conflict, plus a CHANGELOG adjacency).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ravidorr/murphys-laws/72)
<!-- Reviewable:end -->
