### PR TITLE
refactor(mcp): use SDK typed methods + clean audit warnings; bump to 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `murphys-laws-mcp` bumped to `1.2.0`: each of the 7 tool files now calls the SDK's typed methods (`api.searchLaws`, `api.getRandomLaw`, etc.) instead of the low-level `api.get`/`api.post` with hand-rolled response interfaces. Net `-109` lines across `mcp/src/`; the biggest win is `submit-law.ts` which delegates category-slug resolution and discriminated-union error handling to the SDK. No behavior change for AI hosts using the server; the 7 tool names, descriptions, and output formatting are identical.
+
 ### Fixed
+- `npm audit` no longer reports the two moderate advisories that had been nagging every push: `dompurify` bumped `3.3.3 -> 3.4.0` (transitive via `jspdf` in web) and `hono` bumped `4.12.12 -> 4.12.14` (transitive via `@modelcontextprotocol/sdk` in mcp). Resolved cleanly with `npm audit fix`; no consumer code changes. All 3105 tests still pass.
 - `cli-ci.yml` and `mcp-ci.yml` now build the SDK before running typecheck / lint / tests. `murphys-laws-sdk`'s `main` points at `dist/index.js`, and `npm ci` alone doesn't build workspace members, so consumers couldn't resolve the module on a fresh runner.
 
 ### Added

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-mcp",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "MCP server for Murphy's Laws - exposes 1500+ laws to AI agents via Model Context Protocol",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp/src/format.ts
+++ b/mcp/src/format.ts
@@ -1,22 +1,6 @@
-interface Attribution {
-  name?: string;
-  note?: string;
-}
+import type { Attribution, Law } from 'murphys-laws-sdk';
 
-export interface LawData {
-  id: number;
-  title?: string | null;
-  text: string;
-  attributions?: Attribution[] | string;
-  upvotes?: number;
-  downvotes?: number;
-  score?: number;
-  category_name?: string;
-  category_slug?: string;
-  [key: string]: unknown;
-}
-
-function parseAttributions(attributions: Attribution[] | string | undefined): Attribution[] {
+function parseAttributions(attributions: Law['attributions']): Attribution[] {
   if (!attributions) return [];
   if (typeof attributions === 'string') {
     try {
@@ -29,7 +13,7 @@ function parseAttributions(attributions: Attribution[] | string | undefined): At
   return attributions;
 }
 
-export function formatLaw(law: LawData): string {
+export function formatLaw(law: Law): string {
   const lines: string[] = [];
 
   const header = law.title
@@ -59,7 +43,7 @@ export function formatLaw(law: LawData): string {
   return lines.join('\n');
 }
 
-export function formatLawList(laws: LawData[], total?: number): string {
+export function formatLawList(laws: Law[], total?: number): string {
   if (laws.length === 0) {
     return 'No laws found.';
   }

--- a/mcp/src/tools/get-law-of-the-day.ts
+++ b/mcp/src/tools/get-law-of-the-day.ts
@@ -1,11 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { ApiError, type MurphysLawsClient } from 'murphys-laws-sdk';
-import { formatLaw, type LawData } from '../format.js';
-
-interface LawOfDayResponse {
-  law: LawData;
-  featured_date: string;
-}
+import { formatLaw } from '../format.js';
 
 export function registerGetLawOfTheDay(server: McpServer, api: MurphysLawsClient): void {
   server.tool(
@@ -14,7 +9,7 @@ export function registerGetLawOfTheDay(server: McpServer, api: MurphysLawsClient
     {},
     async () => {
       try {
-        const result = await api.get<LawOfDayResponse>('/api/v1/law-of-day');
+        const result = await api.getLawOfTheDay();
 
         const text = `Law of the Day (${result.featured_date})\n\n${formatLaw(result.law)}`;
 

--- a/mcp/src/tools/get-law.ts
+++ b/mcp/src/tools/get-law.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { ApiError, type MurphysLawsClient } from 'murphys-laws-sdk';
-import { formatLaw, type LawData } from '../format.js';
+import { formatLaw } from '../format.js';
 
 export function registerGetLaw(server: McpServer, api: MurphysLawsClient): void {
   server.tool(
@@ -12,7 +12,7 @@ export function registerGetLaw(server: McpServer, api: MurphysLawsClient): void 
     },
     async ({ law_id }) => {
       try {
-        const law = await api.get<LawData>(`/api/v1/laws/${law_id}`);
+        const law = await api.getLaw(law_id);
 
         return {
           content: [{ type: 'text' as const, text: formatLaw(law) }],

--- a/mcp/src/tools/get-laws-by-category.ts
+++ b/mcp/src/tools/get-laws-by-category.ts
@@ -1,14 +1,7 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { MurphysLawsClient } from 'murphys-laws-sdk';
-import { formatLawList, type LawData } from '../format.js';
-
-interface SearchResponse {
-  data: LawData[];
-  total: number;
-  limit: number;
-  offset: number;
-}
+import { formatLawList } from '../format.js';
 
 export function registerGetLawsByCategory(server: McpServer, api: MurphysLawsClient): void {
   server.tool(
@@ -19,14 +12,11 @@ export function registerGetLawsByCategory(server: McpServer, api: MurphysLawsCli
       limit: z.number().min(1).max(25).default(10).describe('Number of results to return (1-25, default 10)'),
     },
     async ({ category_slug, limit }) => {
-      const params = new URLSearchParams({
-        category_slug,
-        limit: String(limit),
+      const result = await api.getLawsByCategory(category_slug, {
+        limit,
         sort: 'score',
         order: 'desc',
       });
-
-      const result = await api.get<SearchResponse>(`/api/v1/laws?${params}`);
 
       return {
         content: [{ type: 'text' as const, text: formatLawList(result.data, result.total) }],

--- a/mcp/src/tools/get-random-law.ts
+++ b/mcp/src/tools/get-random-law.ts
@@ -1,6 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { ApiError, type MurphysLawsClient } from 'murphys-laws-sdk';
-import { formatLaw, type LawData } from '../format.js';
+import { formatLaw } from '../format.js';
 
 export function registerGetRandomLaw(server: McpServer, api: MurphysLawsClient): void {
   server.tool(
@@ -9,7 +9,7 @@ export function registerGetRandomLaw(server: McpServer, api: MurphysLawsClient):
     {},
     async () => {
       try {
-        const law = await api.get<LawData>('/api/v1/laws/random');
+        const law = await api.getRandomLaw();
 
         return {
           content: [{ type: 'text' as const, text: formatLaw(law) }],

--- a/mcp/src/tools/list-categories.ts
+++ b/mcp/src/tools/list-categories.ts
@@ -1,26 +1,13 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { MurphysLawsClient } from 'murphys-laws-sdk';
 
-interface Category {
-  id: number;
-  slug: string;
-  title: string;
-  description: string | null;
-  law_count: number;
-}
-
-interface CategoriesResponse {
-  data: Category[];
-}
-
 export function registerListCategories(server: McpServer, api: MurphysLawsClient): void {
   server.tool(
     'list_categories',
     "List all Murphy's Law categories with their slugs and law counts. Use the slug values to filter searches or browse by category.",
     {},
     async () => {
-      const result = await api.get<CategoriesResponse>('/api/v1/categories');
-      const categories = result.data;
+      const categories = await api.listCategories();
 
       const lines = categories.map(c => {
         const desc = c.description ? ` — ${c.description}` : '';

--- a/mcp/src/tools/search-laws.ts
+++ b/mcp/src/tools/search-laws.ts
@@ -1,14 +1,7 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { MurphysLawsClient } from 'murphys-laws-sdk';
-import { formatLawList, type LawData } from '../format.js';
-
-interface SearchResponse {
-  data: LawData[];
-  total: number;
-  limit: number;
-  offset: number;
-}
+import { formatLawList } from '../format.js';
 
 export function registerSearchLaws(server: McpServer, api: MurphysLawsClient): void {
   server.tool(
@@ -20,17 +13,13 @@ export function registerSearchLaws(server: McpServer, api: MurphysLawsClient): v
       limit: z.number().min(1).max(10).default(5).describe('Number of results to return (1-10, default 5)'),
     },
     async ({ q, category_slug, limit }) => {
-      const params = new URLSearchParams({
+      const result = await api.searchLaws({
         q,
-        limit: String(limit),
+        category_slug,
+        limit,
         sort: 'score',
         order: 'desc',
       });
-      if (category_slug) {
-        params.set('category_slug', category_slug);
-      }
-
-      const result = await api.get<SearchResponse>(`/api/v1/laws?${params}`);
 
       return {
         content: [{ type: 'text' as const, text: formatLawList(result.data, result.total) }],

--- a/mcp/src/tools/submit-law.ts
+++ b/mcp/src/tools/submit-law.ts
@@ -2,31 +2,6 @@ import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { MurphysLawsClient } from 'murphys-laws-sdk';
 
-interface Category {
-  id: number;
-  slug: string;
-  title: string;
-  description: string | null;
-  law_count: number;
-}
-
-interface CategoriesResponse {
-  data: Category[];
-}
-
-interface SubmitSuccessResponse {
-  id: number;
-  title: string;
-  text: string;
-  status: string;
-  message: string;
-}
-
-interface SubmitErrorResponse {
-  error: string;
-  retryAfter?: number;
-}
-
 export function registerSubmitLaw(server: McpServer, api: MurphysLawsClient): void {
   server.tool(
     'submit_law',
@@ -38,71 +13,42 @@ export function registerSubmitLaw(server: McpServer, api: MurphysLawsClient): vo
       category_slug: z.string().optional().describe('Category slug to file the law under. Use list_categories to see available slugs.'),
     },
     async ({ text, title, author, category_slug }) => {
-      // Resolve category_slug to category_id if provided
-      let categoryId: number | undefined;
+      const result = await api.submitLaw({ text, title, author, category_slug });
 
-      if (category_slug) {
-        const categoriesResult = await api.get<CategoriesResponse>('/api/v1/categories');
-        const category = categoriesResult.data.find(c => c.slug === category_slug);
-        if (!category) {
-          return {
-            content: [{ type: 'text' as const, text: `Category "${category_slug}" not found. Use list_categories to see available category slugs.` }],
-            isError: true,
-          };
-        }
-        categoryId = category.id;
+      if (result.kind === 'success') {
+        const lines = [
+          `Law submitted successfully! (ID: ${result.data.id})`,
+          '',
+          `Title: ${result.data.title || '(none)'}`,
+          `Text: "${result.data.text}"`,
+          `Author: ${author?.trim() || 'Anonymous'}`,
+          `Category: ${category_slug || '(none)'}`,
+          `Status: ${result.data.status}`,
+          '',
+          'The law is now in the review queue and will be published after manual approval.',
+        ];
+        return {
+          content: [{ type: 'text' as const, text: lines.join('\n') }],
+        };
       }
 
-      const body: Record<string, unknown> = { text };
-      if (title) body.title = title;
-      if (author) body.author = author;
-      if (categoryId !== undefined) body.category_id = categoryId;
-
-      const { status, data } = await api.post<SubmitSuccessResponse | SubmitErrorResponse>(
-        '/api/v1/laws',
-        body,
-      );
-
-      if (status === 429) {
-        const errData = data as SubmitErrorResponse;
-        const retryIn = errData.retryAfter ?? 60;
+      if (result.kind === 'rate_limited') {
         return {
-          content: [{ type: 'text' as const, text: `Rate limit exceeded. Try again in ${retryIn} seconds.` }],
+          content: [{ type: 'text' as const, text: `Rate limit exceeded. Try again in ${result.retryAfter} seconds.` }],
           isError: true,
         };
       }
 
-      if (status === 400) {
-        const errData = data as SubmitErrorResponse;
+      if (result.kind === 'validation_error') {
         return {
-          content: [{ type: 'text' as const, text: `Validation error: ${errData.error}` }],
+          content: [{ type: 'text' as const, text: `Validation error: ${result.error}` }],
           isError: true,
         };
       }
-
-      if (status !== 201) {
-        return {
-          content: [{ type: 'text' as const, text: `Unexpected response (status ${status}).` }],
-          isError: true,
-        };
-      }
-
-      const successData = data as SubmitSuccessResponse;
-
-      const lines = [
-        `Law submitted successfully! (ID: ${successData.id})`,
-        '',
-        `Title: ${successData.title || '(none)'}`,
-        `Text: "${successData.text}"`,
-        `Author: ${author?.trim() || 'Anonymous'}`,
-        `Category: ${category_slug || '(none)'}`,
-        `Status: ${successData.status}`,
-        '',
-        'The law is now in the review queue and will be published after manual approval.',
-      ];
 
       return {
-        content: [{ type: 'text' as const, text: lines.join('\n') }],
+        content: [{ type: 'text' as const, text: `Unexpected response (status ${result.status}).` }],
+        isError: true,
       };
     },
   );

--- a/mcp/tests/format.test.ts
+++ b/mcp/tests/format.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { formatLaw, formatLawList, type LawData } from '../src/format.js';
+import type { Law } from 'murphys-laws-sdk';
+import { formatLaw, formatLawList } from '../src/format.js';
+
+type LawData = Law;
 
 describe('formatLaw', () => {
   it('renders full law with score and attributions', () => {

--- a/mcp/tests/helpers.ts
+++ b/mcp/tests/helpers.ts
@@ -44,22 +44,24 @@ export interface StubClientBehavior {
     ...args: Parameters<MurphysLawsClient['getLawsByCategory']>
   ) => Promise<unknown>;
   submitLaw?: (...args: Parameters<MurphysLawsClient['submitLaw']>) => Promise<SubmitLawResult>;
-  get?: (path: string) => Promise<unknown>;
-  post?: (path: string, body: unknown) => Promise<{ status: number; data: unknown }>;
+}
+
+function unstubbed(method: string): never {
+  throw new Error(`${method} not stubbed`);
 }
 
 export function createStubClient(behavior: StubClientBehavior): MurphysLawsClient {
   return {
     baseUrl: 'https://api.test',
     userAgent: 'test-agent',
-    get: behavior.get ?? (() => Promise.reject(new Error('get not stubbed'))),
-    post: behavior.post ?? (() => Promise.reject(new Error('post not stubbed'))),
-    searchLaws: behavior.searchLaws ?? (() => Promise.reject(new Error('searchLaws not stubbed'))),
-    getRandomLaw: behavior.getRandomLaw ?? (() => Promise.reject(new Error('getRandomLaw not stubbed'))),
-    getLawOfTheDay: behavior.getLawOfTheDay ?? (() => Promise.reject(new Error('getLawOfTheDay not stubbed'))),
-    getLaw: behavior.getLaw ?? (() => Promise.reject(new Error('getLaw not stubbed'))),
-    listCategories: behavior.listCategories ?? (() => Promise.reject(new Error('listCategories not stubbed'))),
-    getLawsByCategory: behavior.getLawsByCategory ?? (() => Promise.reject(new Error('getLawsByCategory not stubbed'))),
-    submitLaw: behavior.submitLaw ?? (() => Promise.reject(new Error('submitLaw not stubbed'))),
+    get: () => unstubbed('get'),
+    post: () => unstubbed('post'),
+    searchLaws: behavior.searchLaws ?? (() => unstubbed('searchLaws')),
+    getRandomLaw: behavior.getRandomLaw ?? (() => unstubbed('getRandomLaw')),
+    getLawOfTheDay: behavior.getLawOfTheDay ?? (() => unstubbed('getLawOfTheDay')),
+    getLaw: behavior.getLaw ?? (() => unstubbed('getLaw')),
+    listCategories: behavior.listCategories ?? (() => unstubbed('listCategories')),
+    getLawsByCategory: behavior.getLawsByCategory ?? (() => unstubbed('getLawsByCategory')),
+    submitLaw: behavior.submitLaw ?? (() => unstubbed('submitLaw')),
   } as unknown as MurphysLawsClient;
 }

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -24,7 +24,9 @@ function extractTool(
 
 describe('search_laws tool', () => {
   it('registers with correct metadata and schema', () => {
-    const tool = extractTool(registerSearchLaws, { get: async () => ({ data: [], total: 0, limit: 5, offset: 0 }) });
+    const tool = extractTool(registerSearchLaws, {
+      searchLaws: async () => ({ data: [], total: 0, limit: 5, offset: 0 }),
+    });
     expect(tool.name).toBe('search_laws');
     expect(tool.description).toMatch(/Search Murphy's Laws/);
     expect(tool.schema).toHaveProperty('q');
@@ -32,52 +34,42 @@ describe('search_laws tool', () => {
     expect(tool.schema).toHaveProperty('limit');
   });
 
-  it('passes query and forces score+desc sort, returns formatted list', async () => {
-    let capturedPath: string | undefined;
+  it('passes query, forces score+desc sort, and returns formatted list', async () => {
+    let captured: unknown;
     const tool = extractTool(registerSearchLaws, {
-      get: async (path) => {
-        capturedPath = path;
+      searchLaws: async (params) => {
+        captured = params;
         return { data: [{ id: 1, text: 'hi', upvotes: 0, downvotes: 0 }], total: 1, limit: 5, offset: 0 };
       },
     });
     const result = await tool.handler({ q: 'debug', limit: 5 });
-    const url = new URL(`https://api.test${capturedPath}`);
-    expect(url.pathname).toBe('/api/v1/laws');
-    expect(url.searchParams.get('q')).toBe('debug');
-    expect(url.searchParams.get('limit')).toBe('5');
-    expect(url.searchParams.get('sort')).toBe('score');
-    expect(url.searchParams.get('order')).toBe('desc');
-    expect(url.searchParams.get('category_slug')).toBeNull();
+    expect(captured).toEqual({ q: 'debug', category_slug: undefined, limit: 5, sort: 'score', order: 'desc' });
     expect(result.content[0]?.text).toContain("Murphy's Law #1");
   });
 
   it('forwards category_slug when provided', async () => {
-    let capturedPath: string | undefined;
+    let captured: unknown;
     const tool = extractTool(registerSearchLaws, {
-      get: async (path) => {
-        capturedPath = path;
+      searchLaws: async (params) => {
+        captured = params;
         return { data: [], total: 0, limit: 5, offset: 0 };
       },
     });
     await tool.handler({ q: 'x', category_slug: 'computers', limit: 5 });
-    const url = new URL(`https://api.test${capturedPath}`);
-    expect(url.searchParams.get('category_slug')).toBe('computers');
+    expect(captured).toMatchObject({ category_slug: 'computers' });
   });
 });
 
 describe('get_random_law tool', () => {
   it('registers with correct metadata', () => {
-    const tool = extractTool(registerGetRandomLaw, { get: async () => ({ id: 1, text: 'hi' }) });
+    const tool = extractTool(registerGetRandomLaw, { getRandomLaw: async () => ({ id: 1, text: 'x' }) });
     expect(tool.name).toBe('get_random_law');
     expect(tool.description).toMatch(/random/i);
   });
 
   it('returns a formatted law on success', async () => {
     const tool = extractTool(registerGetRandomLaw, {
-      get: async (path) => {
-        expect(path).toBe('/api/v1/laws/random');
-        return { id: 42, text: 'something', upvotes: 3, downvotes: 1 };
-      },
+      getRandomLaw: async () => ({ id: 42, text: 'something', upvotes: 3, downvotes: 1 }),
     });
     const result = await tool.handler({});
     expect(result.content[0]?.text).toContain("Murphy's Law #42");
@@ -86,7 +78,7 @@ describe('get_random_law tool', () => {
 
   it('returns friendly error on 404', async () => {
     const tool = extractTool(registerGetRandomLaw, {
-      get: async () => {
+      getRandomLaw: async () => {
         throw new ApiError(404, 'no laws');
       },
     });
@@ -97,7 +89,7 @@ describe('get_random_law tool', () => {
 
   it('rethrows non-404 ApiError', async () => {
     const tool = extractTool(registerGetRandomLaw, {
-      get: async () => {
+      getRandomLaw: async () => {
         throw new ApiError(500, 'boom');
       },
     });
@@ -106,7 +98,7 @@ describe('get_random_law tool', () => {
 
   it('rethrows non-ApiError errors', async () => {
     const tool = extractTool(registerGetRandomLaw, {
-      get: async () => {
+      getRandomLaw: async () => {
         throw new Error('network');
       },
     });
@@ -117,7 +109,7 @@ describe('get_random_law tool', () => {
 describe('get_law_of_the_day tool', () => {
   it('registers with correct metadata', () => {
     const tool = extractTool(registerGetLawOfTheDay, {
-      get: async () => ({ law: { id: 1, text: 'x' }, featured_date: 'y' }),
+      getLawOfTheDay: async () => ({ law: { id: 1, text: 'x' }, featured_date: 'y' }),
     });
     expect(tool.name).toBe('get_law_of_the_day');
     expect(tool.description).toMatch(/today/i);
@@ -125,10 +117,7 @@ describe('get_law_of_the_day tool', () => {
 
   it('returns formatted law with date header', async () => {
     const tool = extractTool(registerGetLawOfTheDay, {
-      get: async (path) => {
-        expect(path).toBe('/api/v1/law-of-day');
-        return { law: { id: 7, text: 'hi' }, featured_date: '2026-04-20' };
-      },
+      getLawOfTheDay: async () => ({ law: { id: 7, text: 'hi' }, featured_date: '2026-04-20' }),
     });
     const result = await tool.handler({});
     expect(result.content[0]?.text).toContain('Law of the Day (2026-04-20)');
@@ -137,7 +126,7 @@ describe('get_law_of_the_day tool', () => {
 
   it('returns friendly error on 404', async () => {
     const tool = extractTool(registerGetLawOfTheDay, {
-      get: async () => {
+      getLawOfTheDay: async () => {
         throw new ApiError(404, 'nope');
       },
     });
@@ -147,7 +136,7 @@ describe('get_law_of_the_day tool', () => {
 
   it('rethrows non-404 ApiError', async () => {
     const tool = extractTool(registerGetLawOfTheDay, {
-      get: async () => {
+      getLawOfTheDay: async () => {
         throw new ApiError(500, 'boom');
       },
     });
@@ -156,7 +145,7 @@ describe('get_law_of_the_day tool', () => {
 
   it('rethrows non-ApiError errors', async () => {
     const tool = extractTool(registerGetLawOfTheDay, {
-      get: async () => {
+      getLawOfTheDay: async () => {
         throw new Error('network');
       },
     });
@@ -166,27 +155,27 @@ describe('get_law_of_the_day tool', () => {
 
 describe('get_law tool', () => {
   it('registers with correct metadata', () => {
-    const tool = extractTool(registerGetLaw, { get: async () => ({ id: 1, text: 'x' }) });
+    const tool = extractTool(registerGetLaw, { getLaw: async () => ({ id: 1, text: 'x' }) });
     expect(tool.name).toBe('get_law');
     expect(tool.schema).toHaveProperty('law_id');
   });
 
   it('passes the id and returns formatted law', async () => {
-    let capturedPath: string | undefined;
+    let capturedId: number | string | undefined;
     const tool = extractTool(registerGetLaw, {
-      get: async (path) => {
-        capturedPath = path;
+      getLaw: async (id) => {
+        capturedId = id;
         return { id: 9, text: 'the text' };
       },
     });
     const result = await tool.handler({ law_id: 9 });
-    expect(capturedPath).toBe('/api/v1/laws/9');
+    expect(capturedId).toBe(9);
     expect(result.content[0]?.text).toContain("Murphy's Law #9");
   });
 
   it('returns friendly 404 error', async () => {
     const tool = extractTool(registerGetLaw, {
-      get: async () => {
+      getLaw: async () => {
         throw new ApiError(404, 'nope');
       },
     });
@@ -197,7 +186,7 @@ describe('get_law tool', () => {
 
   it('rethrows non-404 ApiError', async () => {
     const tool = extractTool(registerGetLaw, {
-      get: async () => {
+      getLaw: async () => {
         throw new ApiError(500, 'boom');
       },
     });
@@ -206,7 +195,7 @@ describe('get_law tool', () => {
 
   it('rethrows non-ApiError errors', async () => {
     const tool = extractTool(registerGetLaw, {
-      get: async () => {
+      getLaw: async () => {
         throw new Error('network');
       },
     });
@@ -216,25 +205,18 @@ describe('get_law tool', () => {
 
 describe('list_categories tool', () => {
   it('registers with correct metadata', () => {
-    const tool = extractTool(registerListCategories, { get: async () => ({ data: [] }) });
+    const tool = extractTool(registerListCategories, { listCategories: async () => [] });
     expect(tool.name).toBe('list_categories');
   });
 
   it('fetches categories and renders description when present', async () => {
-    let capturedPath: string | undefined;
     const tool = extractTool(registerListCategories, {
-      get: async (path) => {
-        capturedPath = path;
-        return {
-          data: [
-            { id: 1, slug: 'a', title: 'Alpha', description: 'the first', law_count: 2 },
-            { id: 2, slug: 'b', title: 'Beta', description: null, law_count: 5 },
-          ],
-        };
-      },
+      listCategories: async () => [
+        { id: 1, slug: 'a', title: 'Alpha', description: 'the first', law_count: 2 },
+        { id: 2, slug: 'b', title: 'Beta', description: null, law_count: 5 },
+      ],
     });
     const result = await tool.handler({});
-    expect(capturedPath).toBe('/api/v1/categories');
     const text = result.content[0]?.text ?? '';
     expect(text).toContain("Murphy's Law Categories (2 total)");
     expect(text).toContain('Alpha (slug: "a", 2 laws)');
@@ -246,165 +228,134 @@ describe('list_categories tool', () => {
 describe('get_laws_by_category tool', () => {
   it('registers with correct metadata', () => {
     const tool = extractTool(registerGetLawsByCategory, {
-      get: async () => ({ data: [], total: 0, limit: 10, offset: 0 }),
+      getLawsByCategory: async () => ({ data: [], total: 0, limit: 10, offset: 0 }),
     });
     expect(tool.name).toBe('get_laws_by_category');
     expect(tool.schema).toHaveProperty('category_slug');
     expect(tool.schema).toHaveProperty('limit');
   });
 
-  it('hits /api/v1/laws with category filter and returns formatted list', async () => {
-    let capturedPath: string | undefined;
+  it('passes slug and merges sort/order params', async () => {
+    let capturedSlug: string | undefined;
+    let capturedParams: unknown;
     const tool = extractTool(registerGetLawsByCategory, {
-      get: async (path) => {
-        capturedPath = path;
+      getLawsByCategory: async (slug, params) => {
+        capturedSlug = slug;
+        capturedParams = params;
         return { data: [{ id: 1, text: 'hi' }], total: 1, limit: 10, offset: 0 };
       },
     });
     const result = await tool.handler({ category_slug: 'computers', limit: 10 });
-    const url = new URL(`https://api.test${capturedPath}`);
-    expect(url.pathname).toBe('/api/v1/laws');
-    expect(url.searchParams.get('category_slug')).toBe('computers');
-    expect(url.searchParams.get('limit')).toBe('10');
-    expect(url.searchParams.get('sort')).toBe('score');
-    expect(url.searchParams.get('order')).toBe('desc');
+    expect(capturedSlug).toBe('computers');
+    expect(capturedParams).toEqual({ limit: 10, sort: 'score', order: 'desc' });
     expect(result.content[0]?.text).toContain("Murphy's Law #1");
   });
 });
 
 describe('submit_law tool', () => {
-  const validInput = {
-    text: 'A long enough law text to pass validation',
-    title: 'T',
-    author: 'me',
-    category_slug: 'computers',
-  };
+  const validText = 'A long enough law text to pass validation';
 
   it('registers with correct metadata', () => {
-    const tool = extractTool(registerSubmitLaw, {});
+    const tool = extractTool(registerSubmitLaw, {
+      submitLaw: async () => ({
+        kind: 'success',
+        ok: true,
+        status: 201,
+        data: { id: 1, title: '', text: validText, status: 'in_review', message: 'ok' },
+      }),
+    });
     expect(tool.name).toBe('submit_law');
     expect(tool.schema).toHaveProperty('text');
   });
 
-  it('resolves category_slug to id and returns 201 success message', async () => {
-    let postBody: unknown;
+  it('passes args to submitLaw and renders success message', async () => {
+    let captured: unknown;
     const tool = extractTool(registerSubmitLaw, {
-      get: async (path) => {
-        expect(path).toBe('/api/v1/categories');
+      submitLaw: async (input) => {
+        captured = input;
         return {
-          data: [
-            { id: 9, slug: 'computers', title: 'Computers', description: null, law_count: 0 },
-          ],
-        };
-      },
-      post: async (path, body) => {
-        expect(path).toBe('/api/v1/laws');
-        postBody = body;
-        return {
+          kind: 'success',
+          ok: true,
           status: 201,
-          data: {
-            id: 100,
-            title: 'T',
-            text: validInput.text,
-            status: 'in_review',
-            message: 'ok',
-          },
+          data: { id: 100, title: 'T', text: validText, status: 'in_review', message: 'ok' },
         };
       },
     });
-    const result = await tool.handler(validInput);
-    expect(postBody).toEqual({
-      text: validInput.text,
+    const result = await tool.handler({
+      text: validText,
       title: 'T',
       author: 'me',
-      category_id: 9,
+      category_slug: 'computers',
+    });
+    expect(captured).toEqual({
+      text: validText,
+      title: 'T',
+      author: 'me',
+      category_slug: 'computers',
     });
     const text = result.content[0]?.text ?? '';
     expect(text).toContain('Law submitted successfully');
     expect(text).toContain('ID: 100');
     expect(text).toContain('Category: computers');
     expect(text).toContain('Author: me');
-  });
-
-  it('returns error when category_slug not found', async () => {
-    const tool = extractTool(registerSubmitLaw, {
-      get: async () => ({ data: [] }),
-    });
-    const result = await tool.handler({ ...validInput, category_slug: 'nope' });
-    expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('"nope" not found');
-  });
-
-  it('omits category lookup when no slug provided', async () => {
-    let postBody: unknown;
-    const tool = extractTool(registerSubmitLaw, {
-      post: async (_path, body) => {
-        postBody = body;
-        return {
-          status: 201,
-          data: { id: 1, title: '', text: validInput.text, status: 'in_review', message: 'ok' },
-        };
-      },
-    });
-    await tool.handler({ text: validInput.text });
-    expect(postBody).toEqual({ text: validInput.text });
-  });
-
-  it('surfaces 429 with retryAfter', async () => {
-    const tool = extractTool(registerSubmitLaw, {
-      post: async () => ({ status: 429, data: { error: 'Too many', retryAfter: 30 } }),
-    });
-    const result = await tool.handler({ text: validInput.text });
-    expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('30 seconds');
-  });
-
-  it('defaults retryAfter to 60 when missing', async () => {
-    const tool = extractTool(registerSubmitLaw, {
-      post: async () => ({ status: 429, data: {} }),
-    });
-    const result = await tool.handler({ text: validInput.text });
-    expect(result.content[0]?.text).toContain('60 seconds');
-  });
-
-  it('surfaces 400 validation errors', async () => {
-    const tool = extractTool(registerSubmitLaw, {
-      post: async () => ({ status: 400, data: { error: 'text too short' } }),
-    });
-    const result = await tool.handler({ text: validInput.text });
-    expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('text too short');
-  });
-
-  it('surfaces unexpected status codes', async () => {
-    const tool = extractTool(registerSubmitLaw, {
-      post: async () => ({ status: 503, data: {} }),
-    });
-    const result = await tool.handler({ text: validInput.text });
-    expect(result.isError).toBe(true);
-    expect(result.content[0]?.text).toContain('status 503');
+    expect(text).toContain('Status: in_review');
   });
 
   it('falls back to Anonymous when author missing', async () => {
     const tool = extractTool(registerSubmitLaw, {
-      post: async () => ({
+      submitLaw: async () => ({
+        kind: 'success',
+        ok: true,
         status: 201,
-        data: { id: 1, title: '', text: validInput.text, status: 'in_review', message: 'ok' },
+        data: { id: 1, title: '', text: validText, status: 'in_review', message: 'ok' },
       }),
     });
-    const result = await tool.handler({ text: validInput.text });
+    const result = await tool.handler({ text: validText });
     expect(result.content[0]?.text).toContain('Author: Anonymous');
     expect(result.content[0]?.text).toContain('Category: (none)');
+    expect(result.content[0]?.text).toContain('Title: (none)');
   });
 
-  it('shows (none) when title empty in 201 response', async () => {
+  it('surfaces rate_limited with retryAfter', async () => {
     const tool = extractTool(registerSubmitLaw, {
-      post: async () => ({
-        status: 201,
-        data: { id: 1, title: '', text: validInput.text, status: 'in_review', message: 'ok' },
+      submitLaw: async () => ({
+        kind: 'rate_limited',
+        ok: false,
+        status: 429,
+        error: 'Too many',
+        retryAfter: 30,
       }),
     });
-    const result = await tool.handler({ text: validInput.text });
-    expect(result.content[0]?.text).toContain('Title: (none)');
+    const result = await tool.handler({ text: validText });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain('30 seconds');
+  });
+
+  it('surfaces validation_error from SDK', async () => {
+    const tool = extractTool(registerSubmitLaw, {
+      submitLaw: async () => ({
+        kind: 'validation_error',
+        ok: false,
+        status: 400,
+        error: 'text too short',
+      }),
+    });
+    const result = await tool.handler({ text: validText });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain('text too short');
+  });
+
+  it('surfaces unexpected_error with status', async () => {
+    const tool = extractTool(registerSubmitLaw, {
+      submitLaw: async () => ({
+        kind: 'unexpected_error',
+        ok: false,
+        status: 503,
+        error: 'boom',
+      }),
+    });
+    const result = await tool.handler({ text: validText });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain('status 503');
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murphys-laws-monorepo",
-      "version": "2.3.2",
+      "version": "2.4.0",
       "license": "CC0-1.0",
       "workspaces": [
         "backend",
@@ -87,7 +87,7 @@
     },
     "mcp": {
       "name": "murphys-laws-mcp",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "license": "CC0-1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
@@ -6803,9 +6803,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optional": true,
       "optionalDependencies": {
@@ -8256,9 +8256,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "description": "Murphy's Laws - Monorepo for Web, iOS, and Android apps",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
Two related chores bundled into one PR.

## Summary

### MCP tools -> SDK typed methods

Every tool in `mcp/src/tools/` now calls the SDK's typed helpers (`api.searchLaws`, `api.getRandomLaw`, `api.getLawOfTheDay`, `api.getLaw`, `api.listCategories`, `api.getLawsByCategory`, `api.submitLaw`) instead of `api.get('/api/v1/...')` / `api.post(...)` with hand-rolled response interfaces.

The biggest cleanup is `submit-law.ts`: the category-slug-to-id lookup and the response handling (`201 success` / `429 rate_limited` / `400 validation_error` / other `unexpected_error`) all live in the SDK's `submitLaw` now, which returns a discriminated `SubmitLawResult`. The tool just switches on `result.kind`.

- **Net `-109` lines** across `mcp/src/`.
- **No change** to tool names, descriptions, schema, or output formatting. AI hosts using `npx murphys-laws-mcp` see the same 7 tools with the same behavior.
- `format.ts` now imports `Law` / `Attribution` from the SDK so MCP, CLI, and the SDK share the same canonical types.
- Tests rewritten to stub the typed methods. 44 tests, 100% coverage across every source file.

### `npm audit fix`

Quiets the two moderate advisories that showed up on every push:

| Package | From | To | Path | Advisory |
|---|---|---|---|---|
| `dompurify` | 3.3.3 | 3.4.0 | `web -> jspdf -> dompurify` | GHSA-39q2-94rc-95cp |
| `hono` | 4.12.12 | 4.12.14 | `mcp -> @modelcontextprotocol/sdk -> hono` | GHSA-458j-xx4x-4375 |

Both are transitive. Neither codepath is actually hit in our usage (we don't use jspdf's HTML-to-PDF sanitizer path, and the MCP server uses stdio transport, not HTTP). `npm audit fix` resolved cleanly, lockfile-only changes.

### Versions

- Root: 2.3.2 -> 2.4.0 (monorepo Sentry tag)
- MCP: 1.1.2 -> 1.2.0 (minor: internal refactor, public MCP surface identical)
- All other workspaces unchanged.

## Verification

- [x] `npm run ci:mcp` locally: typecheck + lint + 44 tests at 100% coverage + build + boot smoke test all green
- [x] `npm run test:backend` 356/356, `test:web` 2589/2589, `test:sdk` 25/25, `test:cli` 87/87 after the `npm audit fix` lockfile changes
- [x] End-to-end: built `dist/index.js` responds to `initialize` with `version: 1.2.0` and a live `get_random_law` call returns a formatted law from the prod API
- [x] `npm audit` now reports 0 vulnerabilities

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ravidorr/murphys-laws/77)
<!-- Reviewable:end -->
