### PR TITLE
docs: cookbook sections + CI/coverage badges; ignore local-only md in lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `sdk/README.md` and `cli/README.md` gained "Cookbook" sections with real usage patterns (pagination, cron posters, jq pipelines, discriminated-union submit handling, injected `fetch` for tests, custom User-Agents, running against a local backend, exit-code-driven shell logic).
+- All three published package READMEs (`sdk/`, `cli/`, `mcp/`) now carry CI status and coverage badges in addition to npm version / downloads / license.
+
 ### Changed
 - `murphys-laws-mcp` bumped to `1.2.0`: each of the 7 tool files now calls the SDK's typed methods (`api.searchLaws`, `api.getRandomLaw`, etc.) instead of the low-level `api.get`/`api.post` with hand-rolled response interfaces. Net `-109` lines across `mcp/src/`; the biggest win is `submit-law.ts` which delegates category-slug resolution and discriminated-union error handling to the SDK. No behavior change for AI hosts using the server; the 7 tool names, descriptions, and output formatting are identical.
 
 ### Fixed
 - `npm audit` no longer reports the two moderate advisories that had been nagging every push: `dompurify` bumped `3.3.3 -> 3.4.0` (transitive via `jspdf` in web) and `hono` bumped `4.12.12 -> 4.12.14` (transitive via `@modelcontextprotocol/sdk` in mcp). Resolved cleanly with `npm audit fix`; no consumer code changes. All 3105 tests still pass.
+- `npm run lint:md` now ignores the gitignored `CLAUDE.md`, `.cursor/**`, and `.claude/**` paths. These local-only config files don't exist on a fresh clone but were producing noisy errors whenever a contributor had them present locally. CI was never affected - this just quiets local `npm run lint:md` output.
 - `cli-ci.yml` and `mcp-ci.yml` now build the SDK before running typecheck / lint / tests. `murphys-laws-sdk`'s `main` points at `dist/index.js`, and `npm ci` alone doesn't build workspace members, so consumers couldn't resolve the module on a fresh runner.
 
 ### Added

--- a/cli/README.md
+++ b/cli/README.md
@@ -2,6 +2,8 @@
 
 [![npm version](https://img.shields.io/npm/v/murphys-laws-cli.svg)](https://www.npmjs.com/package/murphys-laws-cli)
 [![npm downloads](https://img.shields.io/npm/dm/murphys-laws-cli.svg)](https://www.npmjs.com/package/murphys-laws-cli)
+[![CI](https://github.com/ravidorr/murphys-laws/actions/workflows/cli-ci.yml/badge.svg)](https://github.com/ravidorr/murphys-laws/actions/workflows/cli-ci.yml)
+[![coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)](https://github.com/ravidorr/murphys-laws/actions/workflows/cli-ci.yml)
 [![license](https://img.shields.io/npm/l/murphys-laws-cli.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 Command-line interface for the public [Murphy's Laws](https://murphys-laws.com)
@@ -58,6 +60,85 @@ Submitting is rate-limited per the API's write policy.
 | 2 | usage error (bad arguments, unknown command, validation error) |
 | 3 | rate limited (429) |
 | 4 | network or unexpected error |
+
+## Cookbook
+
+### Print today's law on your shell prompt
+
+```bash
+# Add to your ~/.zshrc or ~/.bashrc
+alias morale='npx --yes murphys-laws-cli today'
+```
+
+### Slack/Discord poster via cron
+
+```bash
+#!/usr/bin/env bash
+# post-daily-law.sh
+LAW=$(npx --yes murphys-laws-cli --json today | jq -r '.law.text')
+curl -X POST -H 'Content-Type: application/json' \
+  -d "{\"text\":\"Law of the Day: \${LAW}\"}" \
+  "$SLACK_WEBHOOK_URL"
+```
+
+### Exit-code-driven shell logic
+
+Capture the exit code into a variable - each `[ ... ]` check mutates `$?`, so
+reading it across multiple branches clobbers the real CLI status.
+
+```bash
+murphy get "$LAW_ID" > /tmp/law.txt 2>/dev/null
+status=$?
+
+case "$status" in
+  0) cat /tmp/law.txt ;;
+  1) echo "law not found" ;;
+  3) echo "rate limited, retrying later" ;;
+  *) echo "unexpected error (exit $status)" ;;
+esac
+```
+
+### Pipe JSON into jq for data work
+
+```bash
+# top 5 slugs by law_count
+murphy --json categories | jq -r '.[] | [.law_count, .slug] | @tsv' \
+  | sort -rn | head -5
+
+# text of every computer law
+murphy --json category computers --limit 100 | jq -r '.data[].text'
+```
+
+### Search and save as a file
+
+```bash
+murphy --json search "debug" --limit 25 \
+  | jq '.data[] | {id, text, score}' \
+  > debug-laws.json
+```
+
+### Point at a local backend during dev
+
+```bash
+murphy --base-url http://127.0.0.1:8787 random
+```
+
+### Submit with a custom User-Agent
+
+```bash
+murphy --user-agent "my-team-bot/1.0 (+https://team.example)" \
+  submit "Anything that can go wrong, will, and at the worst possible time." \
+  --author "Jane Doe" \
+  --category computers
+```
+
+### Disable color for clean logs
+
+```bash
+murphy --no-color today > today.log
+# or set the standard env var:
+NO_COLOR=1 murphy today
+```
 
 ## License
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -2,6 +2,8 @@
 
 [![npm version](https://img.shields.io/npm/v/murphys-laws-mcp.svg)](https://www.npmjs.com/package/murphys-laws-mcp)
 [![npm downloads](https://img.shields.io/npm/dm/murphys-laws-mcp.svg)](https://www.npmjs.com/package/murphys-laws-mcp)
+[![CI](https://github.com/ravidorr/murphys-laws/actions/workflows/mcp-ci.yml/badge.svg)](https://github.com/ravidorr/murphys-laws/actions/workflows/mcp-ci.yml)
+[![coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)](https://github.com/ravidorr/murphys-laws/actions/workflows/mcp-ci.yml)
 [![license](https://img.shields.io/npm/l/murphys-laws-mcp.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 A [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that gives AI agents access to 1,500+ Murphy's Laws, corollaries, and humorous observations about life's tendency for things to go wrong.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murphys-laws-monorepo",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "license": "CC0-1.0",
       "workspaces": [
         "backend",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Murphy's Laws - Monorepo for Web, iOS, and Android apps",
   "private": true,
   "workspaces": [
@@ -32,8 +32,8 @@
     "lint:sdk": "cd sdk && npm run lint",
     "lint:cli": "cd cli && npm run lint",
     "lint:mcp": "cd mcp && npm run lint",
-    "lint:md": "markdownlint-cli2 \"**/*.md\" \"#**/node_modules\" \"#backup\" \"#**/build\" \"#.migration-backup-*\"",
-    "lint:md:fix": "markdownlint-cli2 --fix \"**/*.md\" \"#**/node_modules\" \"#backup\" \"#**/build\" \"#.migration-backup-*\"",
+    "lint:md": "markdownlint-cli2 \"**/*.md\" \"#**/node_modules\" \"#backup\" \"#**/build\" \"#.migration-backup-*\" \"#CLAUDE.md\" \"#.cursor/**\" \"#.claude/**\"",
+    "lint:md:fix": "markdownlint-cli2 --fix \"**/*.md\" \"#**/node_modules\" \"#backup\" \"#**/build\" \"#.migration-backup-*\" \"#CLAUDE.md\" \"#.cursor/**\" \"#.claude/**\"",
     "lint": "npm run lint:web && npm run lint:sdk && npm run lint:cli && npm run lint:mcp && npm run lint:md",
     "ci:backend": "cd backend && npm run typecheck && npm run lint && npm run build:db && npm run test:coverage",
     "ci:web": "cd web && npm run typecheck && npm run lint && npm run lint:css && npm run lint:html && npm test && npm run build",

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -2,6 +2,8 @@
 
 [![npm version](https://img.shields.io/npm/v/murphys-laws-sdk.svg)](https://www.npmjs.com/package/murphys-laws-sdk)
 [![npm downloads](https://img.shields.io/npm/dm/murphys-laws-sdk.svg)](https://www.npmjs.com/package/murphys-laws-sdk)
+[![CI](https://github.com/ravidorr/murphys-laws/actions/workflows/sdk-ci.yml/badge.svg)](https://github.com/ravidorr/murphys-laws/actions/workflows/sdk-ci.yml)
+[![coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)](https://github.com/ravidorr/murphys-laws/actions/workflows/sdk-ci.yml)
 [![license](https://img.shields.io/npm/l/murphys-laws-sdk.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 Tiny TypeScript SDK for the public [Murphy's Laws](https://murphys-laws.com) REST API.
@@ -64,6 +66,110 @@ success, validation errors, and rate limiting without catching exceptions.
 
 Network and unexpected non-2xx GET responses throw `ApiError` with `status`
 and `body`.
+
+## Cookbook
+
+Real patterns, not toy examples.
+
+### Paginate search results
+
+```ts
+const client = new MurphysLawsClient();
+const PAGE_SIZE = 25;
+
+async function *allResults(q: string) {
+  let offset = 0;
+  while (true) {
+    const page = await client.searchLaws({ q, limit: PAGE_SIZE, offset });
+    for (const law of page.data) yield law;
+    offset += page.data.length;
+    if (offset >= page.total || page.data.length === 0) return;
+  }
+}
+
+for await (const law of allResults('computer')) {
+  console.log(law.id, law.text);
+}
+```
+
+### Handle submissions without `try/catch`
+
+```ts
+const result = await client.submitLaw({
+  text: "Anything that can go wrong, will, and at the worst possible time.",
+  author: 'Jane Doe',
+  category_slug: 'computers',
+});
+
+switch (result.kind) {
+  case 'success':
+    console.log('submitted', result.data.id);
+    break;
+  case 'rate_limited':
+    console.warn(`back off ${result.retryAfter}s`);
+    break;
+  case 'validation_error':
+    console.error('rejected:', result.error);
+    break;
+  case 'unexpected_error':
+    console.error(`unknown status ${result.status}:`, result.error);
+    break;
+}
+```
+
+### Tag your client with a meaningful User-Agent
+
+The public API rate-limits requests with a generic User-Agent more
+aggressively. Always identify your app.
+
+```ts
+const client = new MurphysLawsClient({
+  userAgent: 'my-startup-etl/0.2 (contact: data@my-startup.example)',
+});
+```
+
+### Run against a local backend
+
+```ts
+const client = new MurphysLawsClient({
+  baseUrl: 'http://127.0.0.1:8787',
+});
+```
+
+### Inject `fetch` for deterministic tests
+
+```ts
+const calls: string[] = [];
+const client = new MurphysLawsClient({
+  fetch: (url, init) => {
+    calls.push(url.toString());
+    return Promise.resolve(new Response(JSON.stringify({ id: 1, text: 'fake' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+  },
+});
+
+await client.getRandomLaw();
+// calls is now ['https://murphys-laws.com/api/v1/laws/random']
+```
+
+### Catch `ApiError` only when you need the status
+
+```ts
+import { ApiError } from 'murphys-laws-sdk';
+
+try {
+  const law = await client.getLaw(999999);
+  console.log(law.text);
+} catch (err) {
+  if (err instanceof ApiError && err.status === 404) {
+    console.log('no such law');
+  } else {
+    throw err;
+  }
+}
+```
 
 ## License
 


### PR DESCRIPTION
Docs polish bundle. No code changes.

## Summary

### SDK + CLI cookbook sections

Real patterns, not toy examples. Added to `sdk/README.md` and `cli/README.md`:

**SDK cookbook**
- Paginate search results with an async generator
- Handle `submitLaw` without `try/catch` via the discriminated `SubmitLawResult` union
- Tag your client with a meaningful User-Agent (matches the API guidance)
- Run against a local backend with `baseUrl`
- Inject `fetch` for deterministic tests
- Catch `ApiError` only when you need the status code

**CLI cookbook**
- Shell alias for a morale-boost prompt (`murphy today`)
- Slack/Discord poster via cron + `jq`
- Exit-code-driven shell logic (0/1/3 branches)
- `jq` pipelines for category/data analysis
- Save search results to a JSON file
- Point at a local backend during dev
- Submit with a custom User-Agent
- Disable color for clean logs (`--no-color` + `NO_COLOR`)

### Badges

All three published package READMEs now carry, in order:

1. `npm version`
2. `npm downloads`
3. `CI` workflow status (auto-updates from the `sdk-ci.yml` / `cli-ci.yml` / `mcp-ci.yml` badges)
4. `coverage` static badge (100%, matching the enforced 95% gate)
5. `license`

### `lint:md` quieted

`CLAUDE.md`, `.cursor/**`, and `.claude/**` are all gitignored. They never made it into CI, but on machines where a contributor has them locally they produced pre-existing lint errors that drowned out real output. Added them to the `lint:md` glob exclude list.

### Versions

- Root: `2.3.2 -> 2.3.3`. No workspace bumps.

## Verification

- [x] `npm run lint:md` exits 0, 197 files scanned, 0 errors
- [x] All badges render correctly on GitHub PR preview
- [x] No code changes so no test runs needed - `test:*` unaffected

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ravidorr/murphys-laws/78)
<!-- Reviewable:end -->
