### PR TITLE
chore(mcp): fix registry namespace to reverse-DNS; bump to 2.4.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ murphys.db-wal
 .claude/memory/
 CLAUDE.md
 
+# Local-only credentials (MCP Registry signing keys, etc.) - never commit
+.config/
+
 # ===== Monorepo Structure =====
 
 # Migration backups

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `murphys-laws-mcp` bumped to `1.2.1`: corrected `mcpName` (and the matching `name` in `mcp/server.json`) from `murphys-laws.com/murphys-laws` to the reverse-DNS form `com.murphys-laws/murphys-laws` required by the [MCP Registry naming rules](https://modelcontextprotocol.io/registry/authentication). The old value was malformed - neither a `io.github.*` nor a reverse-DNS `com.*` namespace - which is why the initial registry submission never actually landed (registry search still returns 0 hits). The npm package, stdio behavior, and 7 tool surface are otherwise unchanged.
+- `mcp/server.json` pinned both its own `version` and the bundled npm `packages[0].version` to `1.2.1` so registry publish (once credentials are set up) reflects the current artifact on npm.
+
 ### Added
 - `sdk/README.md` and `cli/README.md` gained "Cookbook" sections with real usage patterns (pagination, cron posters, jq pipelines, discriminated-union submit handling, injected `fetch` for tests, custom User-Agents, running against a local backend, exit-code-driven shell logic).
 - All three published package READMEs (`sdk/`, `cli/`, `mcp/`) now carry CI status and coverage badges in addition to npm version / downloads / license.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `murphys-laws-mcp` bumped to `1.2.1`: corrected `mcpName` (and the matching `name` in `mcp/server.json`) from `murphys-laws.com/murphys-laws` to the reverse-DNS form `com.murphys-laws/murphys-laws` required by the [MCP Registry naming rules](https://modelcontextprotocol.io/registry/authentication). The old value was malformed - neither a `io.github.*` nor a reverse-DNS `com.*` namespace - which is why the initial registry submission never actually landed (registry search still returns 0 hits). The npm package, stdio behavior, and 7 tool surface are otherwise unchanged.
 - `mcp/server.json` pinned both its own `version` and the bundled npm `packages[0].version` to `1.2.1` so registry publish (once credentials are set up) reflects the current artifact on npm.
+- `.gitignore` now excludes `.config/`. That directory holds local-only MCP Registry signing keys (Ed25519 private key, DNS-based auth); it must never enter git.
 
 ### Added
 - `sdk/README.md` and `cli/README.md` gained "Cookbook" sections with real usage patterns (pagination, cron posters, jq pipelines, discriminated-union submit handling, injected `fetch` for tests, custom User-Agents, running against a local backend, exit-code-driven shell logic).

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-mcp",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "MCP server for Murphy's Laws - exposes 1500+ laws to AI agents via Model Context Protocol",
   "type": "module",
   "main": "dist/index.js",
@@ -35,7 +35,7 @@
     "model-context-protocol",
     "ai-agent"
   ],
-  "mcpName": "murphys-laws.com/murphys-laws",
+  "mcpName": "com.murphys-laws/murphys-laws",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ravidorr/murphys-laws.git",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -1,17 +1,17 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "murphys-laws.com/murphys-laws",
+  "name": "com.murphys-laws/murphys-laws",
   "description": "Access 1,500+ Murphy's Laws, corollaries, and humorous observations. Search, browse by category, get the law of the day, or submit new laws.",
   "repository": {
     "url": "https://github.com/ravidorr/murphys-laws",
     "source": "github"
   },
-  "version": "1.0.0",
+  "version": "1.2.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "murphys-laws-mcp",
-      "version": "1.0.0",
+      "version": "1.2.1",
       "transport": {
         "type": "stdio"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murphys-laws-monorepo",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "license": "CC0-1.0",
       "workspaces": [
         "backend",
@@ -87,7 +87,7 @@
     },
     "mcp": {
       "name": "murphys-laws-mcp",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "CC0-1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Murphy's Laws - Monorepo for Web, iOS, and Android apps",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
Pre-work for actually getting `murphys-laws-mcp` listed in the MCP Registry. Two commits, tiny surface.

## Why

Registry search for `murphys` / `ravidorr` at `registry.modelcontextprotocol.io` still returns 0 hits despite the old CHANGELOG note claiming it was submitted. Root cause: our `mcpName` is `murphys-laws.com/murphys-laws`, which isn't a valid registry namespace. Per the [auth docs](https://modelcontextprotocol.io/registry/authentication), the format must be either:

- `io.github.<user>/*` (GitHub auth), or
- `com.<example>.*/*` (reverse-DNS, domain auth)

Our value was neither, so the original submission failed silently.

## Summary

- `mcp/package.json`: `mcpName` -> `com.murphys-laws/murphys-laws`, `version` 1.2.0 -> 1.2.1.
- `mcp/server.json`: `name` matches the new `mcpName`. Both `version` fields (top-level and `packages[0].version`) synced to 1.2.1.
- Root: 2.4.1 -> 2.4.2.
- `.gitignore`: excludes `.config/`, which locally holds the Ed25519 signing key for DNS-based registry auth. That directory must never enter git.

No runtime behavior change. Stdio handshake, 7 tools, npm install, `npx murphys-laws-mcp` - all identical to 1.2.0.

## Verification

- [x] `cd mcp && npm run build` clean
- [x] Local stdio handshake smoke: `serverInfo.version: 1.2.1`, `tools/list` returns 7 tools
- [x] `dig +short TXT murphys-laws.com` confirms the required `v=MCPv1; k=ed25519; p=...` record is live (set up by the author out-of-band, not in this PR)
- [x] Public key derived from `.config/mcp/murphys-laws.key.pem` matches the one in DNS

## Follow-up after merge (out of PR scope)

1. `cd mcp && npm publish` - pushes 1.2.1 to npm
2. `mcp-publisher login dns --domain murphys-laws.com --private-key <HEX>` - authenticates with the registry
3. `mcp-publisher publish` - indexes `com.murphys-laws/murphys-laws` -> npm `murphys-laws-mcp@1.2.1`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ravidorr/murphys-laws/79)
<!-- Reviewable:end -->
