### PR TITLE
fix(mcp): trim server.json description to <=100 chars for registry; bump to 2.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `mcp/server.json` description trimmed from 140 chars to 79 so it passes the MCP Registry's `description <= 100` validation. The old longer description on `mcp/package.json` is unchanged (npm has no such limit). The MCP Registry now lists `com.murphys-laws/murphys-laws@1.2.1` and resolves to `npm:murphys-laws-mcp@1.2.1`.
+
 ### Changed
 - `murphys-laws-mcp` bumped to `1.2.1`: corrected `mcpName` (and the matching `name` in `mcp/server.json`) from `murphys-laws.com/murphys-laws` to the reverse-DNS form `com.murphys-laws/murphys-laws` required by the [MCP Registry naming rules](https://modelcontextprotocol.io/registry/authentication). The old value was malformed - neither a `io.github.*` nor a reverse-DNS `com.*` namespace - which is why the initial registry submission never actually landed (registry search still returns 0 hits). The npm package, stdio behavior, and 7 tool surface are otherwise unchanged.
 - `mcp/server.json` pinned both its own `version` and the bundled npm `packages[0].version` to `1.2.1` so registry publish (once credentials are set up) reflects the current artifact on npm.

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.murphys-laws/murphys-laws",
-  "description": "Access 1,500+ Murphy's Laws, corollaries, and humorous observations. Search, browse by category, get the law of the day, or submit new laws.",
+  "description": "Access 1,500+ Murphy's Laws: search, browse by category, random, daily, submit.",
   "repository": {
     "url": "https://github.com/ravidorr/murphys-laws",
     "source": "github"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murphys-laws-monorepo",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "license": "CC0-1.0",
       "workspaces": [
         "backend",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Murphy's Laws - Monorepo for Web, iOS, and Android apps",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
One-liner to align the repo with what's live in the MCP Registry.

## Summary

- `mcp/server.json` `description` trimmed from 140 chars to 79 so it clears the MCP Registry's \`description <= 100\` validation. Original value: *\"Access 1,500+ Murphy's Laws, corollaries, and humorous observations. Search, browse by category, get the law of the day, or submit new laws.\"* (140). New value: *\"Access 1,500+ Murphy's Laws: search, browse by category, random, daily, submit.\"* (79).
- `mcp/package.json` description is **unchanged** — npm has no such limit, and we want the richer text on the npm page.
- Root 2.4.2 -> 2.4.3.

## Context

Registry publish of \`1.2.1\` hit a 422 on the first attempt:

\`\`\`
server returned status 422: {"detail":"validation failed","errors":[{"message":"expected length <= 100","location":"body.description",...}]}
\`\`\`

Fixed the local \`server.json\`, re-ran \`mcp-publisher publish\`, success. This PR just commits the same fix so the repo matches reality:

\`\`\`json
{
  "name": "com.murphys-laws/murphys-laws",
  "version": "1.2.1",
  "description": "Access 1,500+ Murphy's Laws: search, browse by category, random, daily, submit.",
  "packages": [{ "registryType": "npm", "identifier": "murphys-laws-mcp", "version": "1.2.1" }]
}
\`\`\`

## Verification

- [x] \`curl "https://registry.modelcontextprotocol.io/v0/servers?search=com.murphys-laws"\` returns the server with \`status: active\`, \`isLatest: true\`
- [x] \`npm view murphys-laws-mcp version\` -> \`1.2.1\`, \`mcpName\` -> \`com.murphys-laws/murphys-laws\`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ravidorr/murphys-laws/80)
<!-- Reviewable:end -->
