### PR TITLE
feat(mcp): auto-republish to MCP Registry on server.json changes; bump to 2.4.4

### DIFF
--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -73,17 +73,27 @@ jobs:
         run: mcp-publisher publish
 
       - name: Verify entry is live at expected version
+        env:
+          EXPECTED_NAME: ${{ steps.server.outputs.name }}
+          EXPECTED_VERSION: ${{ steps.server.outputs.version }}
         run: |
           set -euo pipefail
           # Allow a beat for the registry to index.
           sleep 5
+          # The search endpoint may return multiple partial matches with
+          # non-guaranteed ordering, so filter by exact server.name match
+          # rather than trusting .servers[0].
           LIVE_VERSION=$(
-            curl -fsSL "https://registry.modelcontextprotocol.io/v0/servers?search=${{ steps.server.outputs.name }}" \
-              | jq -r '.servers[0].server.version // ""'
+            curl -fsSL "https://registry.modelcontextprotocol.io/v0/servers?search=${EXPECTED_NAME}" \
+              | jq -r --arg name "$EXPECTED_NAME" \
+                  'first(.servers[]? | select(.server.name == $name)) // empty | .server.version // ""'
           )
-          EXPECTED="${{ steps.server.outputs.version }}"
-          if [ "$LIVE_VERSION" != "$EXPECTED" ]; then
-            echo "::error::Registry shows version '$LIVE_VERSION', expected '$EXPECTED'"
+          if [ -z "$LIVE_VERSION" ]; then
+            echo "::error::No registry entry found for '$EXPECTED_NAME'"
             exit 1
           fi
-          echo "Registry entry verified: ${{ steps.server.outputs.name }}@$LIVE_VERSION"
+          if [ "$LIVE_VERSION" != "$EXPECTED_VERSION" ]; then
+            echo "::error::Registry shows '$EXPECTED_NAME@$LIVE_VERSION', expected '@$EXPECTED_VERSION'"
+            exit 1
+          fi
+          echo "Registry entry verified: $EXPECTED_NAME@$LIVE_VERSION"

--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -1,0 +1,89 @@
+name: MCP Registry Publish
+
+# Re-publishes mcp/server.json to registry.modelcontextprotocol.io
+# whenever the pinned version changes, or on manual dispatch.
+#
+# Requires repo secret: MCP_PUBLISHER_PRIVATE_KEY
+#   The Ed25519 private key (hex) matching the DNS TXT record on
+#   murphys-laws.com. See mcp/README.md for setup / rotation steps.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'mcp/server.json'
+      - '.github/workflows/mcp-registry-publish.yml'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Read server.json
+        id: server
+        run: |
+          VERSION=$(jq -r '.version' mcp/server.json)
+          NAME=$(jq -r '.name' mcp/server.json)
+          PACKAGE_IDENTIFIER=$(jq -r '.packages[0].identifier' mcp/server.json)
+          PACKAGE_VERSION=$(jq -r '.packages[0].version' mcp/server.json)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "name=$NAME" >> "$GITHUB_OUTPUT"
+          echo "package_identifier=$PACKAGE_IDENTIFIER" >> "$GITHUB_OUTPUT"
+          echo "package_version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Will publish: $NAME@$VERSION -> npm:$PACKAGE_IDENTIFIER@$PACKAGE_VERSION"
+
+      - name: Verify npm artifact exists (guardrail)
+        run: |
+          # If server.json points at a version that never made it to npm,
+          # a successful registry publish would reference a dangling package.
+          # npm view exits non-zero on 404.
+          npm view "${{ steps.server.outputs.package_identifier }}@${{ steps.server.outputs.package_version }}" version
+
+      - name: Install mcp-publisher
+        run: |
+          set -euo pipefail
+          OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+          ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+          URL="https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_${OS}_${ARCH}.tar.gz"
+          curl -fsSL "$URL" | tar xz mcp-publisher
+          sudo mv mcp-publisher /usr/local/bin/
+          mcp-publisher --help >/dev/null
+          echo "mcp-publisher installed"
+
+      - name: Authenticate with registry (DNS auth)
+        env:
+          PRIVATE_KEY: ${{ secrets.MCP_PUBLISHER_PRIVATE_KEY }}
+        run: |
+          if [ -z "$PRIVATE_KEY" ]; then
+            echo "::error::MCP_PUBLISHER_PRIVATE_KEY secret is not set. See mcp/README.md for setup."
+            exit 1
+          fi
+          mcp-publisher login dns --domain murphys-laws.com --private-key "$PRIVATE_KEY"
+
+      - name: Publish to MCP Registry
+        working-directory: mcp
+        run: mcp-publisher publish
+
+      - name: Verify entry is live at expected version
+        run: |
+          set -euo pipefail
+          # Allow a beat for the registry to index.
+          sleep 5
+          LIVE_VERSION=$(
+            curl -fsSL "https://registry.modelcontextprotocol.io/v0/servers?search=${{ steps.server.outputs.name }}" \
+              | jq -r '.servers[0].server.version // ""'
+          )
+          EXPECTED="${{ steps.server.outputs.version }}"
+          if [ "$LIVE_VERSION" != "$EXPECTED" ]; then
+            echo "::error::Registry shows version '$LIVE_VERSION', expected '$EXPECTED'"
+            exit 1
+          fi
+          echo "Registry entry verified: ${{ steps.server.outputs.name }}@$LIVE_VERSION"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- GitHub Actions workflow `.github/workflows/mcp-registry-publish.yml` that re-publishes `com.murphys-laws/murphys-laws` to the MCP Registry whenever `mcp/server.json` changes on `main` (or via manual `workflow_dispatch`). Guardrails: reads the version out of `server.json`, verifies the referenced `murphys-laws-mcp@<version>` actually exists on npm (otherwise aborts), installs `mcp-publisher`, authenticates via DNS using a new `MCP_PUBLISHER_PRIVATE_KEY` repo secret, publishes, and verifies the live registry entry matches. Key rotation instructions in `mcp/README.md`.
+
 ### Fixed
 - `mcp/server.json` description trimmed from 140 chars to 79 so it passes the MCP Registry's `description <= 100` validation. The old longer description on `mcp/package.json` is unchanged (npm has no such limit). The MCP Registry now lists `com.murphys-laws/murphys-laws@1.2.1` and resolves to `npm:murphys-laws-mcp@1.2.1`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- GitHub Actions workflow `.github/workflows/mcp-registry-publish.yml` that re-publishes `com.murphys-laws/murphys-laws` to the MCP Registry whenever `mcp/server.json` changes on `main` (or via manual `workflow_dispatch`). Guardrails: reads the version out of `server.json`, verifies the referenced `murphys-laws-mcp@<version>` actually exists on npm (otherwise aborts), installs `mcp-publisher`, authenticates via DNS using a new `MCP_PUBLISHER_PRIVATE_KEY` repo secret, publishes, and verifies the live registry entry matches. Key rotation instructions in `mcp/README.md`.
+- GitHub Actions workflow `.github/workflows/mcp-registry-publish.yml` that re-publishes `com.murphys-laws/murphys-laws` to the MCP Registry whenever `mcp/server.json` changes on `main` (or via manual `workflow_dispatch`). Guardrails: reads the version out of `server.json`, verifies the referenced `murphys-laws-mcp@<version>` actually exists on npm (otherwise aborts), installs `mcp-publisher`, authenticates via DNS using a new `MCP_PUBLISHER_PRIVATE_KEY` repo secret, publishes, and verifies the live registry entry by filtering the search response for an exact `server.name` match (not `servers[0]`, since search ordering is not guaranteed). Key rotation instructions in `mcp/README.md`.
 
 ### Fixed
 - `mcp/server.json` description trimmed from 140 chars to 79 so it passes the MCP Registry's `description <= 100` validation. The old longer description on `mcp/package.json` is unchanged (npm has no such limit). The MCP Registry now lists `com.murphys-laws/murphys-laws@1.2.1` and resolves to `npm:murphys-laws-mcp@1.2.1`.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -77,6 +77,35 @@ This MCP server uses the public [Murphy's Laws REST API](https://murphys-laws.co
 - [OpenAPI Spec](https://murphys-laws.com/openapi.json)
 - [llms.txt](https://murphys-laws.com/llms.txt)
 
+## MCP Registry publishing
+
+This server is listed in the [MCP Registry](https://registry.modelcontextprotocol.io) as `com.murphys-laws/murphys-laws`. Registry metadata is re-published automatically by [.github/workflows/mcp-registry-publish.yml](../.github/workflows/mcp-registry-publish.yml) whenever `mcp/server.json` changes on `main` (or via `workflow_dispatch`).
+
+Prerequisites for the automation:
+
+1. A DNS TXT record on `murphys-laws.com` containing `v=MCPv1; k=ed25519; p=<PUBLIC_KEY>` (already set; the public key is in the [authentication docs](https://modelcontextprotocol.io/registry/authentication)).
+2. A repo secret `MCP_PUBLISHER_PRIVATE_KEY` holding the matching Ed25519 private key as hex (no separators).
+
+### Key rotation (when needed)
+
+```bash
+# Generate a fresh keypair (on a machine with OpenSSL 3)
+mkdir -p ~/.config/mcp && cd ~/.config/mcp
+openssl genpkey -algorithm Ed25519 -out murphys-laws.key.pem
+chmod 600 murphys-laws.key.pem
+
+# Derive the new TXT record value
+PUBLIC_KEY="$(openssl pkey -in murphys-laws.key.pem -pubout -outform DER | tail -c 32 | base64)"
+echo "v=MCPv1; k=ed25519; p=${PUBLIC_KEY}"
+# Replace the old TXT record on murphys-laws.com with this value
+
+# Extract the hex private key for the GitHub secret
+openssl pkey -in murphys-laws.key.pem -noout -text | grep -A3 'priv:' | tail -n +2 | tr -d ' :\n'
+# Paste the hex output into repo Settings -> Secrets -> MCP_PUBLISHER_PRIVATE_KEY
+```
+
+The private key file at `~/.config/mcp/murphys-laws.key.pem` is the only local copy; back it up to a password manager.
+
 ## License
 
 CC0 1.0 Universal (Public Domain)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murphys-laws-monorepo",
-      "version": "2.4.3",
+      "version": "2.4.4",
       "license": "CC0-1.0",
       "workspaces": [
         "backend",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "Murphy's Laws - Monorepo for Web, iOS, and Android apps",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
Automates the `mcp-publisher publish` dance so future `mcp/server.json` changes don't require a human running terminal commands against DNS keys.

## Summary

New [`.github/workflows/mcp-registry-publish.yml`](.github/workflows/mcp-registry-publish.yml) triggers on:

- `push` to `main` touching `mcp/server.json` (the only file that pins the registry version/metadata)
- Manual `workflow_dispatch` from the Actions tab

Flow:

1. Read `version`, `name`, and `packages[0]` from `mcp/server.json` via `jq`
2. **Guardrail**: `npm view murphys-laws-mcp@<package_version>` to confirm the referenced npm artifact exists. Aborts otherwise - you can't accidentally publish a registry entry that points at a non-existent package
3. Install `mcp-publisher` from its GitHub release archive
4. `mcp-publisher login dns --domain murphys-laws.com --private-key $MCP_PUBLISHER_PRIVATE_KEY`
5. `cd mcp && mcp-publisher publish`
6. **Verify**: re-query the registry, confirm the live `version` matches `server.json`'s, fail the workflow if not

## One-time setup after merge

Add a repo secret `MCP_PUBLISHER_PRIVATE_KEY` containing the Ed25519 private key in hex. Extract it locally:

```bash
/opt/homebrew/opt/openssl@3/bin/openssl pkey \
  -in ~/personal-dev/murphys-laws/.config/mcp/murphys-laws.key.pem \
  -noout -text | grep -A3 'priv:' | tail -n +2 | tr -d ' :\n'
```

Paste the output into **Settings -> Secrets and variables -> Actions -> New repository secret**. Name: `MCP_PUBLISHER_PRIVATE_KEY`.

## Testing after secret is set

Run the workflow via `workflow_dispatch` with no input changes. It'll try to publish `1.2.1` again (the current state). The registry accepts re-publishes of the same version; worst case it's a no-op. Check the final "Verify entry is live" step to confirm everything is green.

## Rotation

`mcp/README.md` now has a "Key rotation" section with the full flow: generate keypair, update DNS TXT record, update the repo secret, done.

## Out of scope

- Rotating the key as part of this PR. Current one still works.
- Adding the secret (needs human action in GitHub UI).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ravidorr/murphys-laws/81)
<!-- Reviewable:end -->
