### PR TITLE
fix(ci): make mcp-registry-publish idempotent; bump to 2.4.5

### DIFF
--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -3,6 +3,11 @@ name: MCP Registry Publish
 # Re-publishes mcp/server.json to registry.modelcontextprotocol.io
 # whenever the pinned version changes, or on manual dispatch.
 #
+# Idempotent: if the registry already has the target version, the publish
+# step is skipped (the registry rejects duplicate-version publishes with
+# 400). The verify step always runs so successful completion always means
+# "registry matches server.json".
+#
 # Requires repo secret: MCP_PUBLISHER_PRIVATE_KEY
 #   The Ed25519 private key (hex) matching the DNS TXT record on
 #   murphys-laws.com. See mcp/README.md for setup / rotation steps.
@@ -38,9 +43,31 @@ jobs:
           echo "name=$NAME" >> "$GITHUB_OUTPUT"
           echo "package_identifier=$PACKAGE_IDENTIFIER" >> "$GITHUB_OUTPUT"
           echo "package_version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "Will publish: $NAME@$VERSION -> npm:$PACKAGE_IDENTIFIER@$PACKAGE_VERSION"
+          echo "Target: $NAME@$VERSION -> npm:$PACKAGE_IDENTIFIER@$PACKAGE_VERSION"
+
+      - name: Check current registry state
+        id: check
+        env:
+          EXPECTED_NAME: ${{ steps.server.outputs.name }}
+          EXPECTED_VERSION: ${{ steps.server.outputs.version }}
+        run: |
+          set -euo pipefail
+          LIVE_VERSION=$(
+            curl -fsSL "https://registry.modelcontextprotocol.io/v0/servers?search=${EXPECTED_NAME}" \
+              | jq -r --arg name "$EXPECTED_NAME" \
+                  'first(.servers[]? | select(.server.name == $name)) // empty | .server.version // ""'
+          )
+          echo "live_version=$LIVE_VERSION" >> "$GITHUB_OUTPUT"
+          if [ "$LIVE_VERSION" = "$EXPECTED_VERSION" ]; then
+            echo "Registry already has $EXPECTED_NAME@$EXPECTED_VERSION - skipping publish"
+            echo "needs_publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Registry has '${LIVE_VERSION:-<none>}', target '$EXPECTED_VERSION' - publish needed"
+            echo "needs_publish=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Verify npm artifact exists (guardrail)
+        if: steps.check.outputs.needs_publish == 'true'
         run: |
           # If server.json points at a version that never made it to npm,
           # a successful registry publish would reference a dangling package.
@@ -48,6 +75,7 @@ jobs:
           npm view "${{ steps.server.outputs.package_identifier }}@${{ steps.server.outputs.package_version }}" version
 
       - name: Install mcp-publisher
+        if: steps.check.outputs.needs_publish == 'true'
         run: |
           set -euo pipefail
           OS=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -59,6 +87,7 @@ jobs:
           echo "mcp-publisher installed"
 
       - name: Authenticate with registry (DNS auth)
+        if: steps.check.outputs.needs_publish == 'true'
         env:
           PRIVATE_KEY: ${{ secrets.MCP_PUBLISHER_PRIVATE_KEY }}
         run: |
@@ -69,6 +98,7 @@ jobs:
           mcp-publisher login dns --domain murphys-laws.com --private-key "$PRIVATE_KEY"
 
       - name: Publish to MCP Registry
+        if: steps.check.outputs.needs_publish == 'true'
         working-directory: mcp
         run: mcp-publisher publish
 
@@ -76,10 +106,14 @@ jobs:
         env:
           EXPECTED_NAME: ${{ steps.server.outputs.name }}
           EXPECTED_VERSION: ${{ steps.server.outputs.version }}
+          NEEDS_PUBLISH: ${{ steps.check.outputs.needs_publish }}
         run: |
           set -euo pipefail
-          # Allow a beat for the registry to index.
-          sleep 5
+          # After a fresh publish, allow a beat for the registry to index.
+          # No-op runs can skip the sleep.
+          if [ "$NEEDS_PUBLISH" = "true" ]; then
+            sleep 5
+          fi
           # The search endpoint may return multiple partial matches with
           # non-guaranteed ordering, so filter by exact server.name match
           # rather than trusting .servers[0].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions workflow `.github/workflows/mcp-registry-publish.yml` that re-publishes `com.murphys-laws/murphys-laws` to the MCP Registry whenever `mcp/server.json` changes on `main` (or via manual `workflow_dispatch`). Guardrails: reads the version out of `server.json`, verifies the referenced `murphys-laws-mcp@<version>` actually exists on npm (otherwise aborts), installs `mcp-publisher`, authenticates via DNS using a new `MCP_PUBLISHER_PRIVATE_KEY` repo secret, publishes, and verifies the live registry entry by filtering the search response for an exact `server.name` match (not `servers[0]`, since search ordering is not guaranteed). Key rotation instructions in `mcp/README.md`.
 
 ### Fixed
+- `mcp-registry-publish.yml` is now idempotent: the registry rejects duplicate-version publishes with a 400 error, so a `workflow_dispatch` or path-trigger re-run with no version change used to fail. New pre-flight step queries the registry for the current version and skips the publish (and auth/install) steps when `server.json`'s version is already live. Verification always runs, so a green workflow always means "registry matches server.json" - whether we just published or the state was already correct.
+
+### Fixed
 - `mcp/server.json` description trimmed from 140 chars to 79 so it passes the MCP Registry's `description <= 100` validation. The old longer description on `mcp/package.json` is unchanged (npm has no such limit). The MCP Registry now lists `com.murphys-laws/murphys-laws@1.2.1` and resolves to `npm:murphys-laws-mcp@1.2.1`.
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murphys-laws-monorepo",
-      "version": "2.4.4",
+      "version": "2.4.5",
       "license": "CC0-1.0",
       "workspaces": [
         "backend",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "description": "Murphy's Laws - Monorepo for Web, iOS, and Android apps",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
Fix for the failure in https://github.com/ravidorr/murphys-laws/actions/runs/24748381689 (second attempt, logs included the real error).

## The bug

The MCP Registry returns `400 Bad Request: cannot publish duplicate version` when you try to publish a `com.murphys-laws/murphys-laws@<version>` that's already live. So any `workflow_dispatch` or re-run of the workflow with no version change in `mcp/server.json` was guaranteed to fail at the publish step.

That defeats the "it's safe to re-run" property we want from a CI workflow. The existing test attempt (re-pushing 1.2.1) hit exactly this.

## The fix

New **Check current registry state** step runs before anything else and compares the live registry version of `com.murphys-laws/murphys-laws` to what's in `server.json`:

- If they match -> set `needs_publish=false`, skip the publish / auth / install steps entirely
- If they don't match (or no entry exists) -> proceed to publish

The **Verify** step always runs, so workflow green always means "registry matches server.json" - whether we just published or it was already correct.

## Flow matrix

| State | Action | Workflow result |
|---|---|---|
| server.json bumped to new version, npm has it | publish + verify | green |
| server.json bumped, npm doesn't have target yet | guardrail aborts at "Verify npm artifact exists" | red, clear error |
| server.json unchanged, registry already has this version | skip publish, verify only | green (fast, ~15s) |
| Someone tampered with registry entry (live version != server.json) | publish overwrites with server.json, verify | green |
| Registry is down / unreachable | curl fails, `set -euo pipefail` aborts | red |

## Versions

- Root: 2.4.4 -> 2.4.5. No workspace bumps (no mcp/ code changed, just CI plumbing).

## Test plan after merge

Run https://github.com/ravidorr/murphys-laws/actions/workflows/mcp-registry-publish.yml via `workflow_dispatch` with `main` selected. Currently `1.2.1` is live on the registry and matches `server.json`, so the new check should short-circuit, skip auth/publish, and land a green run in ~15 seconds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ravidorr/murphys-laws/82)
<!-- Reviewable:end -->
