### PR TITLE
chore: bump android gradle plugin to 9.2.0 and wrapper to 9.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Android toolchain bumped: Android Gradle Plugin `9.1.1` -> `9.2.0` and Gradle wrapper `9.3.1` -> `9.4.1`. Keeps the Android build on current toolchain releases; no app code changes.
+
 ### Added
 - GitHub Actions workflow `.github/workflows/mcp-registry-publish.yml` that re-publishes `com.murphys-laws/murphys-laws` to the MCP Registry whenever `mcp/server.json` changes on `main` (or via manual `workflow_dispatch`). Guardrails: reads the version out of `server.json`, verifies the referenced `murphys-laws-mcp@<version>` actually exists on npm (otherwise aborts), installs `mcp-publisher`, authenticates via DNS using a new `MCP_PUBLISHER_PRIVATE_KEY` repo secret, publishes, and verifies the live registry entry by filtering the search response for an exact `server.name` match (not `servers[0]`, since search ordering is not guaranteed). Key rotation instructions in `mcp/README.md`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Android toolchain bumped: Android Gradle Plugin `9.1.1` -> `9.2.0` and Gradle wrapper `9.3.1` -> `9.4.1`. Keeps the Android build on current toolchain releases; no app code changes.
 
+### Fixed
+- Resolved two high-severity `npm audit` advisories via `npm audit fix`: `@xmldom/xmldom` `0.9.9` -> `0.9.10` and `speech-rule-engine` `4.1.3` -> `4.1.4` (both transitive via MathJax). Unblocks the pre-push audit hook; no consumer code changes.
+
 ### Added
 - GitHub Actions workflow `.github/workflows/mcp-registry-publish.yml` that re-publishes `com.murphys-laws/murphys-laws` to the MCP Registry whenever `mcp/server.json` changes on `main` (or via manual `workflow_dispatch`). Guardrails: reads the version out of `server.json`, verifies the referenced `murphys-laws-mcp@<version>` actually exists on npm (otherwise aborts), installs `mcp-publisher`, authenticates via DNS using a new `MCP_PUBLISHER_PRIVATE_KEY` repo secret, publishes, and verifies the live registry entry by filtering the search response for an exact `server.name` match (not `servers[0]`, since search ordering is not guaranteed). Key rotation instructions in `mcp/README.md`.
 

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -6,7 +6,7 @@
 // by Google in a future AGP release before Gradle 10. Safe to ignore.
 
 plugins {
-    id("com.android.application") version "9.1.1" apply false
+    id("com.android.application") version "9.2.0" apply false
     id("org.jetbrains.kotlin.android") version "2.2.21" apply false
     id("org.jetbrains.kotlin.plugin.compose") version "2.2.21" apply false
     id("com.google.dagger.hilt.android") version "2.57.2" apply false

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/package-lock.json
+++ b/package-lock.json
@@ -5523,9 +5523,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.9.tgz",
-      "integrity": "sha512-qycIHAucxy/LXAYIjmLmtQ8q9GPnMbnjG1KXhWm9o5sCr6pOYDATkMPiTNa6/v8eELyqOQ2FsEqeoFYmgv/gJg==",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.6"
@@ -12301,12 +12301,12 @@
       "license": "MIT"
     },
     "node_modules/speech-rule-engine": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.1.3.tgz",
-      "integrity": "sha512-SBMgkuJYvP4F62daRfBNwYC2nXTEhNXAfsBZ/BB7Ly85/KnbnjmKM7/45ZrFbH6jIMiAliDUDPSZFUuXDvcg6A==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.1.4.tgz",
+      "integrity": "sha512-i/VCLG1fvRc95pMHRqG4aQNscv+9aIsqA2oI7ZQS51sTdUcDHYX6cpT8/tqZ+enjs1tKVwbRBWgxut9SWn+f9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@xmldom/xmldom": "0.9.9",
+        "@xmldom/xmldom": "0.9.10",
         "commander": "13.1.0",
         "wicked-good-xpath": "1.3.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murphys-laws-monorepo",
-      "version": "2.4.5",
+      "version": "2.4.6",
       "license": "CC0-1.0",
       "workspaces": [
         "backend",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "description": "Murphy's Laws - Monorepo for Web, iOS, and Android apps",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Summary

- Bump Android Gradle Plugin `9.1.1` -> `9.2.0` and Gradle wrapper `9.3.1` -> `9.4.1` to stay on current Android toolchain releases. No app code changes.
- Bump root monorepo version `2.4.5` -> `2.4.6` per the ship workflow.
- Incidental security fix: `npm audit fix` clears two high-severity GHSA advisories on `@xmldom/xmldom` (`0.9.9` -> `0.9.10`, transitive via `speech-rule-engine` `4.1.3` -> `4.1.4`). This was required to pass the pre-push audit hook; no consumer code changes.

## Test plan

- [ ] Android app still builds locally with the new AGP + Gradle combo (`./gradlew assembleDebug` under `android/`).
- [ ] CI green on this PR (backend typecheck/lint/tests + web typecheck/lint/unit/E2E + coverage thresholds).
- [ ] `npm audit --audit-level=high` reports 0 vulnerabilities.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ravidorr/murphys-laws/83)
<!-- Reviewable:end -->
