### PR TITLE
feat: adopt DESIGN.md as the web design-system contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `web/DESIGN.md`: adopted Google Labs' [DESIGN.md](https://github.com/google-labs-code/design.md) format as the web's design-system contract. YAML front matter (52 colors, 9 typography levels, 5 rounding tokens, 10 spacing tokens, 15 components) is regenerated from `web/styles/partials/variables.css` by `web/scripts/sync-design-tokens.ts`; the Markdown body is authored (tone, a11y posture, elevation, shapes, workflow). New `npm run design:check` in `web/` runs drift detection plus `@google/design.md lint` and is wired into `ci:web`; WCAG-AA contrast failures are promoted from warnings to errors so sub-threshold pairs fail the build. Stitch-generated mockups live in `web/.stitch/` (gitignored) and are never shipped. Adds 35 vitest cases and pins `@google/design.md@0.1.1` as a web devDependency.
+
 ### Changed
 - Android toolchain bumped: Android Gradle Plugin `9.1.1` -> `9.2.0` and Gradle wrapper `9.3.1` -> `9.4.1`. Keeps the Android build on current toolchain releases; no app code changes.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.4.6",
+  "version": "2.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murphys-laws-monorepo",
-      "version": "2.4.6",
+      "version": "2.4.7",
       "license": "CC0-1.0",
       "workspaces": [
         "backend",
@@ -119,6 +119,52 @@
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@alcalzone/ansi-tokenize": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.2.5.tgz",
+      "integrity": "sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@alcalzone/ansi-tokenize/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@apideck/better-ajv-errors": {
       "version": "0.3.7",
@@ -2669,6 +2715,229 @@
         }
       }
     },
+    "node_modules/@google/design.md": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@google/design.md/-/design.md-0.1.1.tgz",
+      "integrity": "sha512-S5xdF4DrELQwY2186vishZ9ZHxzMo7eikM8FHFNDS87oULElLDF5eko33DPCXtWyzEPyzkZWuUTpm/M0pPtbNQ==",
+      "dev": true,
+      "dependencies": {
+        "@json-render/core": "^0.16.0",
+        "@json-render/ink": "^0.16.0",
+        "citty": "^0.1.6",
+        "ink": "^7.0.0",
+        "mdast": "^3.0.0",
+        "react": "^19.2.5",
+        "remark-frontmatter": "^5.0.0",
+        "remark-mdx": "^3.1.1",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.5",
+        "unist-util-visit": "^5.1.0",
+        "yaml": "^2.7.1",
+        "zod": "^3.24.0"
+      },
+      "bin": {
+        "design.md": "dist/index.js"
+      }
+    },
+    "node_modules/@google/design.md/node_modules/@alcalzone/ansi-tokenize": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.3.0.tgz",
+      "integrity": "sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google/design.md/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@google/design.md/node_modules/cli-boxes": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-4.0.1.tgz",
+      "integrity": "sha512-5IOn+jcCEHEraYolBPs/sT4BxYCe2nHg374OPiItB1O96KZFseS2gthU4twyYzeDcFew4DaUM/xwc5BQf08JJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.20 <19 || >=20.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@google/design.md/node_modules/cli-truncate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-6.0.0.tgz",
+      "integrity": "sha512-3+YKIUFsohD9MIoOFPFBldjAlnfCmCDcqe6aYGFqlDTRKg80p4wg35L+j83QQ63iOlKRccEkbn8IuM++HsgEjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^9.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@google/design.md/node_modules/ink": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/ink/-/ink-7.0.1.tgz",
+      "integrity": "sha512-o6LAC268PLawlGVYrXTyaTfke4VtJftEheuwbgkQf7yvSXyWp1nRwBbAyKEkWXFZZsW/la5wrMuNbuBvZK2C1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alcalzone/ansi-tokenize": "^0.3.0",
+        "ansi-escapes": "^7.3.0",
+        "ansi-styles": "^6.2.3",
+        "auto-bind": "^5.0.1",
+        "chalk": "^5.6.2",
+        "cli-boxes": "^4.0.1",
+        "cli-cursor": "^4.0.0",
+        "cli-truncate": "^6.0.0",
+        "code-excerpt": "^4.0.0",
+        "es-toolkit": "^1.45.1",
+        "indent-string": "^5.0.0",
+        "is-in-ci": "^2.0.0",
+        "patch-console": "^2.0.0",
+        "react-reconciler": "^0.33.0",
+        "scheduler": "^0.27.0",
+        "signal-exit": "^3.0.7",
+        "slice-ansi": "^9.0.0",
+        "stack-utils": "^2.0.6",
+        "string-width": "^8.2.0",
+        "terminal-size": "^4.0.1",
+        "type-fest": "^5.5.0",
+        "widest-line": "^6.0.0",
+        "wrap-ansi": "^10.0.0",
+        "ws": "^8.20.0",
+        "yoga-layout": "~3.2.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "@types/react": ">=19.2.0",
+        "react": ">=19.2.0",
+        "react-devtools-core": ">=6.1.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-devtools-core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@google/design.md/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@google/design.md/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@google/design.md/node_modules/slice-ansi": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-9.0.0.tgz",
+      "integrity": "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@google/design.md/node_modules/string-width": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@google/design.md/node_modules/type-fest": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@google/design.md/node_modules/wrap-ansi": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
+      "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "string-width": "^8.2.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.13",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
@@ -3301,6 +3570,44 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@json-render/core": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@json-render/core/-/core-0.16.0.tgz",
+      "integrity": "sha512-qQp8BB/3pWYapTGXBDSBMXRCdrC05VJPLL3drXMPX/QbUB3nuvtyXUGmAZFUz8eLUy7JImODvb3GNIq38dGzhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^4.3.6"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@json-render/core/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@json-render/ink": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@json-render/ink/-/ink-0.16.0.tgz",
+      "integrity": "sha512-oJ/MbW0zLkv3i6MSZVk8QiI6mbyvtA0XZpJEuJBTCf1yjMMdxN16Mz/uW/5AV9FMOBjZXohQPONLMxvSxil6Bg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@json-render/core": "0.16.0",
+        "marked": "^17.0.0"
+      },
+      "peerDependencies": {
+        "ink": "^6.0.0",
+        "react": "^19.0.0"
       }
     },
     "node_modules/@keyv/serialize": {
@@ -5031,6 +5338,26 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
     },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -5043,6 +5370,16 @@
       "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -5620,6 +5957,22 @@
         }
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
@@ -5768,6 +6121,19 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/auto-bind": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
+      "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -5844,6 +6210,17 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/balanced-match": {
@@ -6209,6 +6586,17 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -6219,10 +6607,34 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/character-entities": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
       "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -6283,11 +6695,149 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
     },
+    "node_modules/citty": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
+      "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "consola": "^3.2.3"
+      }
+    },
     "node_modules/cjs-module-lexer": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
       "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
       "license": "MIT"
+    },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/code-excerpt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
+      "integrity": "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "convert-to-spaces": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -6336,6 +6886,16 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
@@ -6364,6 +6924,16 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/convert-to-spaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
+      "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -6915,6 +7485,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
@@ -7064,6 +7647,17 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.0.tgz",
+      "integrity": "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -7389,6 +7983,39 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-visit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-2.0.0.tgz",
+      "integrity": "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-util-visit/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -7518,6 +8145,13 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -7598,6 +8232,20 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fault": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-2.0.1.tgz",
+      "integrity": "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/fflate": {
@@ -7747,6 +8395,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
       }
     },
     "node_modules/forwarded": {
@@ -8533,6 +9190,19 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -8544,6 +9214,149 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
+    },
+    "node_modules/ink": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/ink/-/ink-6.8.0.tgz",
+      "integrity": "sha512-sbl1RdLOgkO9isK42WCZlJCFN9hb++sX9dsklOvfd1YQ3bQ2AiFu12Q6tFlr0HvEUvzraJntQCCpfEoUe9DSzA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@alcalzone/ansi-tokenize": "^0.2.4",
+        "ansi-escapes": "^7.3.0",
+        "ansi-styles": "^6.2.1",
+        "auto-bind": "^5.0.1",
+        "chalk": "^5.6.0",
+        "cli-boxes": "^3.0.0",
+        "cli-cursor": "^4.0.0",
+        "cli-truncate": "^5.1.1",
+        "code-excerpt": "^4.0.0",
+        "es-toolkit": "^1.39.10",
+        "indent-string": "^5.0.0",
+        "is-in-ci": "^2.0.0",
+        "patch-console": "^2.0.0",
+        "react-reconciler": "^0.33.0",
+        "scheduler": "^0.27.0",
+        "signal-exit": "^3.0.7",
+        "slice-ansi": "^8.0.0",
+        "stack-utils": "^2.0.6",
+        "string-width": "^8.1.1",
+        "terminal-size": "^4.0.1",
+        "type-fest": "^5.4.1",
+        "widest-line": "^6.0.0",
+        "wrap-ansi": "^9.0.0",
+        "ws": "^8.18.0",
+        "yoga-layout": "~3.2.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@types/react": ">=19.0.0",
+        "react": ">=19.0.0",
+        "react-devtools-core": ">=6.1.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-devtools-core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ink/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ink/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/ink/node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ink/node_modules/string-width": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
+      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ink/node_modules/type-fest": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "peer": true,
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -8853,6 +9666,22 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-in-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-2.0.0.tgz",
+      "integrity": "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-in-ci": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -8927,6 +9756,19 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
       "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9608,6 +10450,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "11.3.2",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.2.tgz",
@@ -9826,6 +10679,224 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/mdast": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast/-/mdast-3.0.0.tgz",
+      "integrity": "sha512-xySmf8g4fPKMeC07jXGz971EkLbWAJ83s4US2Tj9lEdnZ142UP5grN73H1Xd3HzrdbU5o9GYYP/y8F9ZSwLE9g==",
+      "deprecated": "`mdast` was renamed to `remark`",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mdast-util-frontmatter": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-2.0.1.tgz",
+      "integrity": "sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-extension-frontmatter": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-frontmatter/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-mdx": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz",
+      "integrity": "sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
@@ -9981,6 +11052,23 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/micromark-extension-frontmatter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-2.0.0.tgz",
+      "integrity": "sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fault": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/micromark-extension-gfm-autolink-literal": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
@@ -10057,6 +11145,113 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/micromark-extension-mdx-expression": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-3.0.1.tgz",
+      "integrity": "sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-mdx-jsx": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-3.0.2.tgz",
+      "integrity": "sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "micromark-factory-mdx-expression": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdx-md": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz",
+      "integrity": "sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs/-/micromark-extension-mdxjs-3.0.0.tgz",
+      "integrity": "sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.0.0",
+        "acorn-jsx": "^5.0.0",
+        "micromark-extension-mdx-expression": "^3.0.0",
+        "micromark-extension-mdx-jsx": "^3.0.0",
+        "micromark-extension-mdx-md": "^2.0.0",
+        "micromark-extension-mdxjs-esm": "^3.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-mdxjs-esm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-3.0.0.tgz",
+      "integrity": "sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/micromark-factory-destination": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
@@ -10100,6 +11295,34 @@
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-mdx-expression": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.3.tgz",
+      "integrity": "sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-events-to-acorn": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-position-from-estree": "^2.0.0",
+        "vfile-message": "^4.0.0"
       }
     },
     "node_modules/micromark-factory-space": {
@@ -10273,6 +11496,29 @@
         "micromark-util-symbol": "^2.0.0"
       }
     },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
     "node_modules/micromark-util-encode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
@@ -10288,6 +11534,39 @@
           "url": "https://opencollective.com/unified"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-events-to-acorn": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.3.tgz",
+      "integrity": "sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-visit": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "vfile-message": "^4.0.0"
+      }
+    },
+    "node_modules/micromark-util-events-to-acorn/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/micromark-util-html-tag-name": {
@@ -10463,6 +11742,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/mimic-response": {
@@ -10744,6 +12033,22 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -10907,6 +12212,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/patch-console": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
+      "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/path-exists": {
@@ -11444,6 +12759,32 @@
         "rc": "cli.js"
       }
     },
+    "node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.33.0.tgz",
+      "integrity": "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -11580,6 +12921,71 @@
         "regjsparser": "bin/parser"
       }
     },
+    "node_modules/remark-frontmatter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-5.0.0.tgz",
+      "integrity": "sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-frontmatter": "^2.0.0",
+        "micromark-extension-frontmatter": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-mdx": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-3.1.1.tgz",
+      "integrity": "sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-mdx": "^3.0.0",
+        "micromark-extension-mdxjs": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -11641,6 +13047,30 @@
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
+    },
+    "node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/reusify": {
       "version": "1.1.0",
@@ -11841,6 +13271,13 @@
       "engines": {
         "node": ">=v12.22.7"
       }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -12323,6 +13760,29 @@
         "node": ">=18"
       }
     },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -12481,6 +13941,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/stringify-object": {
@@ -12856,6 +14331,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -12908,6 +14396,19 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/terminal-size": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/terminal-size/-/terminal-size-4.0.1.tgz",
+      "integrity": "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -13082,6 +14583,17 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
@@ -13386,6 +14898,33 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unified/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unique-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
@@ -13398,6 +14937,114 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unist-util-position-from-estree": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz",
+      "integrity": "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position-from-estree/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unist-util-visit/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "2.0.1",
@@ -13515,6 +15162,50 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vfile/node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.3.2",
@@ -13951,6 +15642,22 @@
       "integrity": "sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw==",
       "license": "MIT"
     },
+    "node_modules/widest-line": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-6.0.0.tgz",
+      "integrity": "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -14340,6 +16047,58 @@
         "workbox-core": "7.4.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -14357,6 +16116,28 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xml-name-validator": {
@@ -14385,6 +16166,22 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -14396,6 +16193,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "3.25.76",
@@ -14413,6 +16217,17 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "sdk": {
@@ -14437,7 +16252,7 @@
     },
     "web": {
       "name": "murphys-laws-web",
-      "version": "3.2.3",
+      "version": "3.2.4",
       "license": "CC0-1.0",
       "dependencies": {
         "@sentry/browser": "^10.25.0",
@@ -14449,6 +16264,7 @@
       "devDependencies": {
         "@axe-core/playwright": "^4.11.1",
         "@eslint/js": "^10.0.0",
+        "@google/design.md": "0.1.1",
         "@playwright/test": "^1.58.2",
         "@sentry/vite-plugin": "^0.4.0",
         "@types/node": "^25.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.4.6",
+  "version": "2.4.7",
   "description": "Murphy's Laws - Monorepo for Web, iOS, and Android apps",
   "private": true,
   "workspaces": [
@@ -36,7 +36,7 @@
     "lint:md:fix": "markdownlint-cli2 --fix \"**/*.md\" \"#**/node_modules\" \"#backup\" \"#**/build\" \"#.migration-backup-*\" \"#CLAUDE.md\" \"#.cursor/**\" \"#.claude/**\"",
     "lint": "npm run lint:web && npm run lint:sdk && npm run lint:cli && npm run lint:mcp && npm run lint:md",
     "ci:backend": "cd backend && npm run typecheck && npm run lint && npm run build:db && npm run test:coverage",
-    "ci:web": "cd web && npm run typecheck && npm run lint && npm run lint:css && npm run lint:html && npm test && npm run build",
+    "ci:web": "cd web && npm run typecheck && npm run lint && npm run lint:css && npm run lint:html && npm run design:check && npm test && npm run build",
     "ci:sdk": "cd sdk && npm run typecheck && npm run lint && npm run test:coverage",
     "ci:cli": "cd cli && npm run typecheck && npm run lint && npm run test:coverage",
     "ci:mcp": "cd mcp && npm run typecheck && npm run lint && npm run test:coverage && npm run build",

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,4 @@
+# Local-only scratch dir for Stitch (https://stitch.withgoogle.com) mockups.
+# DESIGN.md is the canonical design-system artifact; Stitch output is for
+# ideation only and must never be committed or shipped.
+.stitch/

--- a/web/DESIGN.md
+++ b/web/DESIGN.md
@@ -1,0 +1,316 @@
+---
+version: alpha
+name: "Murphy's Law Archive"
+description: "Design tokens and component contracts for murphys-laws.com. Derived from web/styles/partials/variables.css; the Markdown body below is authored."
+colors:
+  bg: "#ffffff"
+  fg: "#111827"
+  muted-fg: "#4b5563"
+  primary: "#030213"
+  text-high-contrast: "#000000"
+  btn-primary-bg: "#0d5ea1"
+  btn-primary-fg: "#ffffff"
+  success: "#15803d"
+  success-bg: "#dcfce7"
+  success-border: "#86efac"
+  success-text: "#166534"
+  success-dark: "#0b3d22"
+  error: "#b91c1c"
+  error-bg: "#fee2e2"
+  error-border: "#fca5a5"
+  error-text: "#991b1b"
+  error-dark: "#5e0010"
+  favorite-color: "#c2185b"
+  favorite-bg: "#fce4ec"
+  favorite-border: "#f48fb1"
+  warning-bg: "#fff8e1"
+  warning-text: "#5a4300"
+  orange-bg: "#ffe9d6"
+  orange-text: "#6a2e00"
+  dark-bg: "#f0d6d6"
+  dark-text: "#2b0000"
+  important: "#b91c1c"
+  white: "#ffffff"
+  highlight: "#fef08a"
+  gradient-blue: "#2563eb"
+  gradient-dark-1: "#2d2d2d"
+  gradient-dark-2: "#1a1a1a"
+  dark-bg-primary: "#0b0b11"
+  dark-fg-primary: "#e9eaee"
+  dark-muted-fg: "#9ca3af"
+  dark-primary: "#6366f1"
+  dark-text-high-contrast: "#ffffff"
+  dark-link: "#9ecbff"
+  dark-link-visited: "#b8a6ff"
+  dark-link-hover: "#cfe5ff"
+  dark-success-bg: "#103424"
+  dark-success-fg: "#c9f1dd"
+  dark-warning-bg: "#3b2f07"
+  dark-warning-fg: "#ffe29a"
+  dark-orange-bg: "#402214"
+  dark-orange-fg: "#ffd9bf"
+  dark-error-bg: "#3c151d"
+  dark-error-fg: "#ffc4cc"
+  dark-dark-bg: "#2a1b1b"
+  dark-dark-fg: "#f0d6d6"
+  dark-favorite-color: "#f06292"
+  dark-favorite-bg: "#3c1525"
+typography:
+  display:
+    fontFamily: "Work Sans, system-ui"
+    fontSize: "48px"
+    fontWeight: 700
+    lineHeight: 1.1
+    letterSpacing: "-0.02em"
+  h1:
+    fontFamily: "Work Sans, system-ui"
+    fontSize: "36px"
+    fontWeight: 700
+    lineHeight: 1.25
+  h2:
+    fontFamily: "Work Sans, system-ui"
+    fontSize: "30px"
+    fontWeight: 600
+    lineHeight: 1.25
+  h3:
+    fontFamily: "Work Sans, system-ui"
+    fontSize: "24px"
+    fontWeight: 600
+    lineHeight: 1.375
+  h4:
+    fontFamily: "Work Sans, system-ui"
+    fontSize: "20px"
+    fontWeight: 600
+    lineHeight: 1.375
+  body-lg:
+    fontFamily: "Work Sans, system-ui"
+    fontSize: "18px"
+    fontWeight: 400
+    lineHeight: 1.5
+  body-md:
+    fontFamily: "Work Sans, system-ui"
+    fontSize: "16px"
+    fontWeight: 400
+    lineHeight: 1.5
+  body-sm:
+    fontFamily: "Work Sans, system-ui"
+    fontSize: "14px"
+    fontWeight: 400
+    lineHeight: 1.5
+  caption:
+    fontFamily: "Work Sans, system-ui"
+    fontSize: "12px"
+    fontWeight: 500
+    lineHeight: 1.25
+rounded:
+  sm: "4px"
+  md: "6px"
+  lg: "8px"
+  xl: "12px"
+  full: "9999px"
+spacing:
+  "1": "4px"
+  "2": "8px"
+  "3": "12px"
+  "4": "16px"
+  "5": "20px"
+  "6": "24px"
+  "8": "32px"
+  "10": "40px"
+  "12": "48px"
+  "16": "64px"
+components:
+  btn-primary:
+    backgroundColor: "{colors.btn-primary-bg}"
+    textColor: "{colors.btn-primary-fg}"
+    rounded: "{rounded.md}"
+    typography: "{typography.body-md}"
+  btn-outline:
+    backgroundColor: "{colors.bg}"
+    textColor: "{colors.fg}"
+    rounded: "{rounded.md}"
+    typography: "{typography.body-md}"
+  card:
+    backgroundColor: "{colors.bg}"
+    textColor: "{colors.fg}"
+    rounded: "{rounded.lg}"
+  section-card:
+    backgroundColor: "{colors.bg}"
+    textColor: "{colors.fg}"
+    rounded: "{rounded.lg}"
+  input:
+    backgroundColor: "{colors.bg}"
+    textColor: "{colors.fg}"
+    rounded: "{rounded.sm}"
+    typography: "{typography.body-md}"
+  modal:
+    backgroundColor: "{colors.bg}"
+    textColor: "{colors.fg}"
+    rounded: "{rounded.lg}"
+  nav-dropdown:
+    backgroundColor: "{colors.bg}"
+    textColor: "{colors.fg}"
+    rounded: "{rounded.md}"
+  brand-badge:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.white}"
+    rounded: "{rounded.full}"
+  blockquote:
+    backgroundColor: "{colors.bg}"
+    textColor: "{colors.fg}"
+  pagination:
+    backgroundColor: "{colors.bg}"
+    textColor: "{colors.fg}"
+    rounded: "{rounded.md}"
+  calc-ok:
+    backgroundColor: "{colors.success-bg}"
+    textColor: "{colors.success-text}"
+  calc-warn:
+    backgroundColor: "{colors.warning-bg}"
+    textColor: "{colors.warning-text}"
+  calc-orange:
+    backgroundColor: "{colors.orange-bg}"
+    textColor: "{colors.orange-text}"
+  calc-danger:
+    backgroundColor: "{colors.error-bg}"
+    textColor: "{colors.error-text}"
+  calc-dark:
+    backgroundColor: "{colors.dark-bg}"
+    textColor: "{colors.dark-text}"
+---
+# Murphy's Law Archive - Design System
+
+## Overview
+
+Murphy's Law Archive is an archive, not an app. The product celebrates
+the history of a truism; the visual system should feel like a tidy
+reference work with a dry sense of humor rather than a trendy SaaS
+dashboard. Typography carries most of the personality; chrome stays
+quiet. Color is used to reinforce meaning (success, error, favorite,
+calculator state) and almost never for decoration.
+
+Tone: archive, academic, dry humor. Density: comfortable but not airy.
+Accessibility is non-negotiable; the token values in this file are tuned
+for WCAG 2.1 AA contrast in both light and dark modes.
+
+## Colors
+
+The palette is neutral-first. A single deep blue carries interaction.
+Semantic palettes (success, error, warning, orange, dark, favorite)
+are used by the calculators and form feedback surfaces. All light-mode
+tokens are paired with a dark-mode counterpart (prefixed `dark-`)
+activated via `prefers-color-scheme: dark` or `:root[data-theme="dark"]`.
+
+- Neutral surfaces: `bg`, `fg`, `muted-fg`, `text-high-contrast`.
+- Brand: `primary` for brand badge, `btn-primary-bg` / `btn-primary-fg`
+  for primary calls-to-action. `btn-primary-bg` is tuned darker than a
+  default Tailwind blue to pass WCAG AA on white.
+- Semantic: `success`, `error`, `favorite-color`, `important`, plus
+  paired `-bg` / `-text` / `-border` tokens for badges and callouts.
+- Calculator states: `calc-ok` / `calc-warn` / `calc-orange` / `calc-danger`
+  / `calc-dark` map to the semantic palette.
+
+Tokens that rely on runtime alpha or `color-mix()` (borders, shadows,
+hover layers) are intentionally not represented as YAML tokens because
+DESIGN.md requires literal `#HEX` values. Treat them as implementation
+details of the CSS, not as part of the design contract. See
+`web/styles/partials/variables.css` and `theme.css` for the actual
+definitions.
+
+## Typography
+
+The web uses a single family, **Work Sans**, with a system-font fallback
+stack. The type scale is a Major Third (1.25) progression from 12 px
+caption to 48 px display. Weights run 400 / 500 / 600 / 700 / 800;
+600 is the default for headings. Line heights are tight on display
+copy (1.1-1.25) and relaxed on body (1.5).
+
+The `typography` tokens in the YAML front matter are semantic levels
+(`display`, `h1`..`h4`, `body-lg`..`body-sm`, `caption`) composed
+from the atomic `--text-*`, `--font-*`, and `--leading-*` primitives
+in `variables.css`.
+
+## Layout
+
+Spacing follows a 4 px base unit: `space-1` (4 px) through `space-16`
+(64 px). The scale is not linear - it skips through Fibonacci-adjacent
+steps (1, 2, 3, 4, 5, 6, 8, 10, 12, 16) to keep composition rhythmic.
+
+Layouts are content-first, single-column on mobile, with a centered
+max-width on desktop. The header uses a sticky translucent surface
+(`color-mix` over `bg`); the footer uses a lightly tinted surface
+(`color-mix` over `bg` at ~90%).
+
+## Elevation & Depth
+
+Elevation is the combination of a `color-mix` surface tint and a
+stacked `box-shadow` (inset highlight plus outer drop). It is not
+tokenized; the three tiers below live directly in
+`web/styles/partials/theme.css` and `components.css`, not in YAML:
+
+- Resting cards: subtle ~8 px blur at low alpha over a lightly tinted
+  surface (`color-mix(in oklab, var(--bg) 88%, white 12%)` in dark
+  mode, `var(--bg)` in light mode).
+- Floating surfaces (dropdowns, modals): 20-24 px blur at higher alpha
+  over the same tinted surface, with a 1 px inset highlight.
+- High-contrast mode: elevations collapse to 2 px solid borders via
+  `prefers-contrast: more` or `:root[data-contrast="more"]`; shadows
+  are effectively dropped.
+
+## Shapes
+
+Corner radii use a five-level scale, exposed as the `rounded` tokens
+in the YAML front matter: `sm` 4 px, `md` 6 px, `lg` 8 px, `xl` 12 px,
+`full` 9999 px (pill). Buttons use `md`, cards and modals use `lg`,
+the brand badge uses `full`. There is no "none" level: zero radius is
+a deliberate choice, not a token.
+
+## Components
+
+The `components` section in the YAML front matter assigns color and
+shape tokens to the core shipped components. It is not exhaustive - it
+covers the primitives that agents most often need to reproduce
+(buttons, cards, inputs, modal, brand badge, blockquote, pagination,
+and the calculator state pills). Dark-mode overrides are handled in
+`theme.css`; agents should assume any component is theme-aware and
+use the `dark-*` color tokens for dark surfaces.
+
+## Do's and Don'ts
+
+- Do keep type doing the heavy lifting. Chrome should be quiet.
+- Do use semantic color tokens (`success-*`, `error-*`, etc.) - never
+  raw hex in components.
+- Do keep contrast at WCAG AA or better. The token values already pass;
+  reach for them, not "close enough" shades.
+- Don't introduce Material Design 3 components or styles. Stitch will
+  default to MD3; steer it with this DESIGN.md and discard MD3-specific
+  output.
+- Don't ship emojis in UI copy - ESLint and markdownlint both reject
+  them repo-wide.
+- Don't use inline styles. `html-validate` blocks them; put styles in
+  the relevant partial under `web/styles/partials/`.
+- Don't edit the YAML front matter by hand. It is regenerated from
+  `variables.css` by `npm run design:sync` in the `web` workspace.
+
+## Workflow
+
+This DESIGN.md is the single source of truth for agents (Cursor,
+Claude, Stitch, Figma). The authoritative values live in
+`web/styles/partials/variables.css`. The sync script
+`web/scripts/sync-design-tokens.ts` parses that file and regenerates
+the YAML front matter above; it does not touch this Markdown body.
+
+- **Change a color or spacing value:** edit `variables.css`, then run
+  `npm --prefix web run design:sync`. CI enforces no drift via
+  `npm run design:check` in `ci:web`.
+- **Change a typography level, component contract, or radius scale:**
+  edit the constants at the top of `sync-design-tokens.ts` and re-run
+  `design:sync`. These are semantic decisions that do not have a 1:1
+  representation in CSS.
+- **Use Stitch for ideation:** seed Stitch with this file. Keep
+  generated mockups in `web/.stitch/` (gitignored). Do not ship
+  Stitch-generated HTML/CSS; translate mockups by hand into the
+  vanilla-TS components under `web/src/components/`.
+- **Validate:** `npm --prefix web run design:check` runs
+  `design:sync --check` for drift and `@google/design.md lint` for
+  structural correctness and WCAG contrast.

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-web",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Murphy's Laws Web Application",
   "type": "module",
   "scripts": {
@@ -21,7 +21,9 @@
     "lint:css:fix": "stylelint \"styles/**/*.css\" --fix",
     "lint:html": "html-validate \"index.html\" \"src/**/*.html\" \"e2e/**/*.html\"",
     "optimize:images": "tsx scripts/optimize-images.ts",
-    "optimize:images:dry-run": "tsx scripts/optimize-images.ts --dry-run"
+    "optimize:images:dry-run": "tsx scripts/optimize-images.ts --dry-run",
+    "design:sync": "tsx scripts/sync-design-tokens.ts",
+    "design:check": "tsx scripts/sync-design-tokens.ts --check && tsx scripts/design-md-lint.ts"
   },
   "keywords": [
     "murphys-law",
@@ -40,6 +42,7 @@
   "devDependencies": {
     "@axe-core/playwright": "^4.11.1",
     "@eslint/js": "^10.0.0",
+    "@google/design.md": "0.1.1",
     "@playwright/test": "^1.58.2",
     "@sentry/vite-plugin": "^0.4.0",
     "@types/node": "^25.3.0",

--- a/web/scripts/design-md-lint.ts
+++ b/web/scripts/design-md-lint.ts
@@ -1,0 +1,159 @@
+/**
+ * Thin wrapper around `@google/design.md lint` that:
+ *   - runs the upstream linter over web/DESIGN.md
+ *   - fails the process on any finding with severity `error`
+ *   - surfaces warnings and infos to stdout for visibility
+ *   - treats "defined but never referenced" warnings as acceptable
+ *     (dark-mode tokens are authored for agent consumption, not for
+ *     component contracts, so they will always be "unreferenced")
+ *
+ * The upstream package is proprietary-licensed and is pinned as a
+ * devDependency in web/package.json. It is never bundled into the
+ * shipped web artifact.
+ */
+
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const DESIGN_MD_PATH = path.resolve(__dirname, '../DESIGN.md');
+const DESIGN_MD_PACKAGE_SPEC = '@google/design.md@0.1.1';
+
+interface Finding {
+  severity: 'error' | 'warning' | 'info';
+  path?: string;
+  message: string;
+}
+
+interface LintReport {
+  findings: Finding[];
+  summary: { errors: number; warnings: number; infos: number };
+}
+
+export interface RunLintOptions {
+  designMdPath: string;
+  packageSpec: string;
+  runner: (args: string[]) => { status: number | null; stdout: string; stderr: string };
+  logger: Pick<Console, 'log' | 'error'>;
+}
+
+/**
+ * Whether a warning is considered acceptable for this repo.
+ *
+ * DESIGN.md flags every color token that is not consumed by a
+ * component-level contract. We use `dark-*` tokens as direct consumer
+ * tokens (agents read them, CSS in `theme.css` references them) rather
+ * than via component sub-tokens, so "unreferenced" warnings on them
+ * are expected and not actionable here.
+ */
+export function isIgnorableWarning(finding: Finding): boolean {
+  if (finding.severity !== 'warning') return false;
+  return /is defined but never referenced by any component/.test(finding.message);
+}
+
+/**
+ * Whether a warning should be promoted to an error for this repo.
+ *
+ * WCAG contrast failures ship as `warning`s from the upstream linter
+ * but the project contract (see CLAUDE.md + DESIGN.md "Do's and Don'ts")
+ * treats WCAG AA as a hard gate; any token pair that falls below
+ * threshold must fail the build rather than silently land.
+ */
+export function isWcagFailureWarning(finding: Finding): boolean {
+  if (finding.severity !== 'warning') return false;
+  return /below WCAG\s*A{1,3}/i.test(finding.message);
+}
+
+export function runDesignMdLint(options: RunLintOptions): 0 | 1 {
+  const { status, stdout, stderr } = options.runner([
+    '--yes',
+    options.packageSpec,
+    'lint',
+    '--format',
+    'json',
+    options.designMdPath,
+  ]);
+
+  if (status === null || status > 1) {
+    options.logger.error(
+      `design.md lint failed to run (exit ${String(status)}):\n${stderr}`,
+    );
+    return 1;
+  }
+
+  let report: LintReport;
+  try {
+    report = JSON.parse(stdout) as LintReport;
+  } catch (err) {
+    options.logger.error(
+      `Could not parse design.md lint output as JSON: ${(err as Error).message}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+    );
+    return 1;
+  }
+
+  const upstreamErrors = report.findings.filter((f) => f.severity === 'error');
+  const wcagFailures = report.findings.filter(isWcagFailureWarning);
+  const otherWarnings = report.findings.filter(
+    (f) =>
+      f.severity === 'warning' &&
+      !isIgnorableWarning(f) &&
+      !isWcagFailureWarning(f),
+  );
+  const infos = report.findings.filter((f) => f.severity === 'info');
+
+  for (const info of infos) {
+    options.logger.log(`info  ${info.path ?? ''}: ${info.message}`);
+  }
+  for (const warn of otherWarnings) {
+    options.logger.log(`warn  ${warn.path ?? ''}: ${warn.message}`);
+  }
+  for (const error of upstreamErrors) {
+    options.logger.error(`error ${error.path ?? ''}: ${error.message}`);
+  }
+  for (const wcag of wcagFailures) {
+    options.logger.error(
+      `error ${wcag.path ?? ''}: ${wcag.message} (promoted from warning: WCAG AA is a hard gate)`,
+    );
+  }
+
+  const ignored = report.findings.filter(
+    (f) => f.severity === 'warning' && isIgnorableWarning(f),
+  ).length;
+
+  const totalErrors = upstreamErrors.length + wcagFailures.length;
+  options.logger.log(
+    `design.md lint: ${totalErrors} error(s), ${otherWarnings.length} warning(s), ${ignored} ignored-warning(s), ${infos.length} info(s).`,
+  );
+
+  return totalErrors === 0 ? 0 : 1;
+}
+
+function isMain(): boolean {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return import.meta.url === new URL(`file://${entry}`).href;
+  } catch {
+    return false;
+  }
+}
+
+if (isMain()) {
+  const code = runDesignMdLint({
+    designMdPath: DESIGN_MD_PATH,
+    packageSpec: DESIGN_MD_PACKAGE_SPEC,
+    runner: (args) => {
+      const r = spawnSync('npx', args, { encoding: 'utf8' });
+      return {
+        status: r.status,
+        stdout: r.stdout ?? '',
+        stderr: r.stderr ?? '',
+      };
+    },
+    logger: console,
+  });
+  process.exit(code);
+}

--- a/web/scripts/sync-design-tokens.ts
+++ b/web/scripts/sync-design-tokens.ts
@@ -1,0 +1,653 @@
+/**
+ * Sync web/DESIGN.md YAML front matter from web/styles/partials/variables.css.
+ *
+ * variables.css is the source of truth for concrete color / spacing values.
+ * DESIGN.md is a derived artifact whose YAML front matter mirrors those
+ * tokens for AI agents, Figma, Stitch, and any other DESIGN.md consumer.
+ *
+ * The markdown body of DESIGN.md is authored and is preserved verbatim;
+ * typography / components / rounded blocks are semantic and are owned by
+ * this script (they do not appear in variables.css as atomic primitives).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const VARIABLES_CSS_PATH = path.resolve(
+  __dirname,
+  '../styles/partials/variables.css',
+);
+const DESIGN_MD_PATH = path.resolve(__dirname, '../DESIGN.md');
+
+const HEX_COLOR_RE = /^#([0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+const SPACING_KEY_RE = /^space-(\d+)$/;
+
+export interface ClassifiedTokens {
+  colors: Map<string, string>;
+  spacing: Map<string, string>;
+}
+
+/**
+ * Parse a `:root { ... }` block out of a CSS source and return a
+ * Map of custom-property name (without the leading `--`) to raw value.
+ */
+export function parseCssVariables(cssContent: string): Map<string, string> {
+  const vars = new Map<string, string>();
+  const rootMatch = cssContent.match(/:root\s*\{([\s\S]*?)\}/);
+  if (!rootMatch || rootMatch[1] === undefined) {
+    return vars;
+  }
+  const body = rootMatch[1].replace(/\/\*[\s\S]*?\*\//g, '');
+  const decl = /--([a-z0-9-]+)\s*:\s*([^;]+);/gi;
+  let m: RegExpExecArray | null;
+  while ((m = decl.exec(body)) !== null) {
+    const name = m[1];
+    const rawValue = m[2];
+    if (name === undefined || rawValue === undefined) continue;
+    vars.set(name, rawValue.trim());
+  }
+  return vars;
+}
+
+/**
+ * Split the parsed CSS variables into DESIGN.md-safe buckets.
+ *
+ * - colors: any variable whose value is a literal hex color (SRGB).
+ *   Alpha (`rgb()` / `rgba()`) and runtime values (`color-mix(...)`,
+ *   `var(--other)`) are intentionally excluded - DESIGN.md only allows
+ *   `#HEX` in the YAML front matter and agents would otherwise see
+ *   broken token values.
+ * - spacing: any variable named `space-N`, emitted as a `Npx` Dimension.
+ *   Input is expected in rem (matching the Tailwind-style 1rem = 16px
+ *   convention used in variables.css).
+ */
+export function classifyTokens(
+  vars: Map<string, string>,
+): ClassifiedTokens {
+  const colors = new Map<string, string>();
+  const spacing = new Map<string, string>();
+
+  for (const [name, value] of vars) {
+    const spaceMatch = name.match(SPACING_KEY_RE);
+    if (spaceMatch && spaceMatch[1] !== undefined) {
+      const px = remOrPxToPx(value);
+      if (px !== null) {
+        spacing.set(spaceMatch[1], `${px}px`);
+      }
+      continue;
+    }
+    const normalized = normalizeHex(value);
+    if (normalized !== null) {
+      colors.set(name, normalized);
+    }
+  }
+
+  return { colors, spacing };
+}
+
+function normalizeHex(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!HEX_COLOR_RE.test(trimmed)) {
+    return null;
+  }
+  // Expand shorthand #abc / #abcd to 6/8-digit form for consistency.
+  const hex = trimmed.slice(1);
+  if (hex.length === 3 || hex.length === 4) {
+    return '#' + hex.split('').map((c) => c + c).join('').toLowerCase();
+  }
+  return '#' + hex.toLowerCase();
+}
+
+function remOrPxToPx(raw: string): number | null {
+  const trimmed = raw.trim();
+  const remMatch = trimmed.match(/^([\d.]+)rem$/);
+  if (remMatch && remMatch[1] !== undefined) {
+    return Math.round(parseFloat(remMatch[1]) * 16);
+  }
+  const pxMatch = trimmed.match(/^([\d.]+)px$/);
+  if (pxMatch && pxMatch[1] !== undefined) {
+    return Math.round(parseFloat(pxMatch[1]));
+  }
+  return null;
+}
+
+/**
+ * Typography levels for DESIGN.md. The web codebase does not tokenize
+ * semantic levels in CSS (it ships atomic --text-* / --font-* /
+ * --leading-* primitives and composes them in each component), so the
+ * mapping from primitives to semantic levels lives here.
+ *
+ * Keep this in sync with web/styles/partials/base.css and components.css.
+ */
+const TYPOGRAPHY_LEVELS: Record<
+  string,
+  {
+    fontFamily: string;
+    fontSize: string;
+    fontWeight: number;
+    lineHeight: number | string;
+    letterSpacing?: string;
+  }
+> = {
+  display: {
+    fontFamily: 'Work Sans, system-ui',
+    fontSize: '48px',
+    fontWeight: 700,
+    lineHeight: 1.1,
+    letterSpacing: '-0.02em',
+  },
+  h1: {
+    fontFamily: 'Work Sans, system-ui',
+    fontSize: '36px',
+    fontWeight: 700,
+    lineHeight: 1.25,
+  },
+  h2: {
+    fontFamily: 'Work Sans, system-ui',
+    fontSize: '30px',
+    fontWeight: 600,
+    lineHeight: 1.25,
+  },
+  h3: {
+    fontFamily: 'Work Sans, system-ui',
+    fontSize: '24px',
+    fontWeight: 600,
+    lineHeight: 1.375,
+  },
+  h4: {
+    fontFamily: 'Work Sans, system-ui',
+    fontSize: '20px',
+    fontWeight: 600,
+    lineHeight: 1.375,
+  },
+  'body-lg': {
+    fontFamily: 'Work Sans, system-ui',
+    fontSize: '18px',
+    fontWeight: 400,
+    lineHeight: 1.5,
+  },
+  'body-md': {
+    fontFamily: 'Work Sans, system-ui',
+    fontSize: '16px',
+    fontWeight: 400,
+    lineHeight: 1.5,
+  },
+  'body-sm': {
+    fontFamily: 'Work Sans, system-ui',
+    fontSize: '14px',
+    fontWeight: 400,
+    lineHeight: 1.5,
+  },
+  caption: {
+    fontFamily: 'Work Sans, system-ui',
+    fontSize: '12px',
+    fontWeight: 500,
+    lineHeight: 1.25,
+  },
+};
+
+/**
+ * Corner-radius scale. Derived from observed border-radius values in
+ * components.css and calculator.css; not currently tokenized in CSS.
+ */
+const ROUNDED_SCALE: Record<string, string> = {
+  sm: '4px',
+  md: '6px',
+  lg: '8px',
+  xl: '12px',
+  full: '9999px',
+};
+
+/**
+ * Component contracts. Each entry references color tokens from the
+ * generated `colors` block via DESIGN.md's `{path.to.token}` syntax.
+ * Keep this aligned with web/styles/partials/components.css and theme.css.
+ */
+const COMPONENTS: Record<string, Record<string, string>> = {
+  'btn-primary': {
+    backgroundColor: '{colors.btn-primary-bg}',
+    textColor: '{colors.btn-primary-fg}',
+    rounded: '{rounded.md}',
+    typography: '{typography.body-md}',
+  },
+  'btn-outline': {
+    backgroundColor: '{colors.bg}',
+    textColor: '{colors.fg}',
+    rounded: '{rounded.md}',
+    typography: '{typography.body-md}',
+  },
+  card: {
+    backgroundColor: '{colors.bg}',
+    textColor: '{colors.fg}',
+    rounded: '{rounded.lg}',
+  },
+  'section-card': {
+    backgroundColor: '{colors.bg}',
+    textColor: '{colors.fg}',
+    rounded: '{rounded.lg}',
+  },
+  input: {
+    backgroundColor: '{colors.bg}',
+    textColor: '{colors.fg}',
+    rounded: '{rounded.sm}',
+    typography: '{typography.body-md}',
+  },
+  modal: {
+    backgroundColor: '{colors.bg}',
+    textColor: '{colors.fg}',
+    rounded: '{rounded.lg}',
+  },
+  'nav-dropdown': {
+    backgroundColor: '{colors.bg}',
+    textColor: '{colors.fg}',
+    rounded: '{rounded.md}',
+  },
+  'brand-badge': {
+    backgroundColor: '{colors.primary}',
+    textColor: '{colors.white}',
+    rounded: '{rounded.full}',
+  },
+  blockquote: {
+    backgroundColor: '{colors.bg}',
+    textColor: '{colors.fg}',
+  },
+  pagination: {
+    backgroundColor: '{colors.bg}',
+    textColor: '{colors.fg}',
+    rounded: '{rounded.md}',
+  },
+  'calc-ok': {
+    backgroundColor: '{colors.success-bg}',
+    textColor: '{colors.success-text}',
+  },
+  'calc-warn': {
+    backgroundColor: '{colors.warning-bg}',
+    textColor: '{colors.warning-text}',
+  },
+  'calc-orange': {
+    backgroundColor: '{colors.orange-bg}',
+    textColor: '{colors.orange-text}',
+  },
+  'calc-danger': {
+    backgroundColor: '{colors.error-bg}',
+    textColor: '{colors.error-text}',
+  },
+  'calc-dark': {
+    backgroundColor: '{colors.dark-bg}',
+    textColor: '{colors.dark-text}',
+  },
+};
+
+const NAME = "Murphy's Law Archive";
+const VERSION = 'alpha';
+const DESCRIPTION =
+  'Design tokens and component contracts for murphys-laws.com. Derived from web/styles/partials/variables.css; the Markdown body below is authored.';
+
+const COLOR_KEY_ORDER = [
+  // Core light-mode
+  'bg',
+  'fg',
+  'muted-fg',
+  'primary',
+  'text-high-contrast',
+  'btn-primary-bg',
+  'btn-primary-fg',
+  // Semantic: success
+  'success',
+  'success-bg',
+  'success-border',
+  'success-text',
+  'success-dark',
+  // Semantic: error
+  'error',
+  'error-bg',
+  'error-border',
+  'error-text',
+  'error-dark',
+  // Semantic: favorite
+  'favorite-color',
+  'favorite-bg',
+  'favorite-border',
+  // Semantic: warning
+  'warning-bg',
+  'warning-text',
+  // Semantic: orange
+  'orange-bg',
+  'orange-text',
+  // Semantic: "dark" (distinct from dark mode: dark emphasis state)
+  'dark-bg',
+  'dark-text',
+  // Semantic: important
+  'important',
+  // UI
+  'white',
+  'highlight',
+  // Gradient
+  'gradient-blue',
+  'gradient-dark-1',
+  'gradient-dark-2',
+  // Dark-mode counterparts
+  'dark-bg-primary',
+  'dark-fg-primary',
+  'dark-muted-fg',
+  'dark-primary',
+  'dark-text-high-contrast',
+  'dark-link',
+  'dark-link-visited',
+  'dark-link-hover',
+  'dark-success-bg',
+  'dark-success-fg',
+  'dark-warning-bg',
+  'dark-warning-fg',
+  'dark-orange-bg',
+  'dark-orange-fg',
+  'dark-error-bg',
+  'dark-error-fg',
+  'dark-dark-bg',
+  'dark-dark-fg',
+  'dark-favorite-color',
+  'dark-favorite-bg',
+];
+
+const SPACING_KEY_ORDER = ['1', '2', '3', '4', '5', '6', '8', '10', '12', '16'];
+
+function quoteYamlKey(key: string): string {
+  return /^[A-Za-z_][A-Za-z0-9_-]*$/.test(key) ? key : JSON.stringify(key);
+}
+
+function yamlString(value: string): string {
+  return JSON.stringify(value);
+}
+
+export function renderFrontMatter(parsed: ClassifiedTokens): string {
+  const lines: string[] = [];
+  lines.push(`version: ${VERSION}`);
+  lines.push(`name: ${yamlString(NAME)}`);
+  lines.push(`description: ${yamlString(DESCRIPTION)}`);
+
+  lines.push('colors:');
+  const seenColorKeys = new Set<string>();
+  for (const key of COLOR_KEY_ORDER) {
+    const value = parsed.colors.get(key);
+    if (value !== undefined) {
+      lines.push(`  ${quoteYamlKey(key)}: ${yamlString(value)}`);
+      seenColorKeys.add(key);
+    }
+  }
+  // Trailing tokens the author added to variables.css after the ordered list.
+  const extraColors = [...parsed.colors.keys()]
+    .filter((k) => !seenColorKeys.has(k))
+    .sort();
+  for (const key of extraColors) {
+    lines.push(`  ${quoteYamlKey(key)}: ${yamlString(parsed.colors.get(key)!)}`);
+  }
+
+  lines.push('typography:');
+  for (const [level, props] of Object.entries(TYPOGRAPHY_LEVELS)) {
+    lines.push(`  ${quoteYamlKey(level)}:`);
+    lines.push(`    fontFamily: ${yamlString(props.fontFamily)}`);
+    lines.push(`    fontSize: ${yamlString(props.fontSize)}`);
+    lines.push(`    fontWeight: ${props.fontWeight}`);
+    lines.push(`    lineHeight: ${props.lineHeight}`);
+    if (props.letterSpacing !== undefined) {
+      lines.push(`    letterSpacing: ${yamlString(props.letterSpacing)}`);
+    }
+  }
+
+  lines.push('rounded:');
+  for (const [level, dim] of Object.entries(ROUNDED_SCALE)) {
+    lines.push(`  ${quoteYamlKey(level)}: ${yamlString(dim)}`);
+  }
+
+  lines.push('spacing:');
+  const seenSpacingKeys = new Set<string>();
+  for (const key of SPACING_KEY_ORDER) {
+    const value = parsed.spacing.get(key);
+    if (value !== undefined) {
+      lines.push(`  ${quoteYamlKey(key)}: ${yamlString(value)}`);
+      seenSpacingKeys.add(key);
+    }
+  }
+  const extraSpacing = [...parsed.spacing.keys()]
+    .filter((k) => !seenSpacingKeys.has(k))
+    .sort((a, b) => Number(a) - Number(b));
+  for (const key of extraSpacing) {
+    lines.push(`  ${quoteYamlKey(key)}: ${yamlString(parsed.spacing.get(key)!)}`);
+  }
+
+  lines.push('components:');
+  for (const [name, props] of Object.entries(COMPONENTS)) {
+    lines.push(`  ${quoteYamlKey(name)}:`);
+    for (const [prop, value] of Object.entries(props)) {
+      lines.push(`    ${quoteYamlKey(prop)}: ${yamlString(value)}`);
+    }
+  }
+
+  return lines.join('\n') + '\n';
+}
+
+const DEFAULT_BODY = `# Murphy's Law Archive - Design System
+
+## Overview
+
+Murphy's Law Archive is an archive, not an app. The product celebrates
+the history of a truism; the visual system should feel like a tidy
+reference work with a dry sense of humor rather than a trendy SaaS
+dashboard. Typography carries most of the personality; chrome stays
+quiet. Color is used to reinforce meaning (success, error, favorite,
+calculator state) and almost never for decoration.
+
+Tone: archive, academic, dry humor. Density: comfortable but not airy.
+Accessibility is non-negotiable; the token values in this file are tuned
+for WCAG 2.1 AA contrast in both light and dark modes.
+
+## Colors
+
+The palette is neutral-first. A single deep blue carries interaction.
+Semantic palettes (success, error, warning, orange, dark, favorite)
+are used by the calculators and form feedback surfaces. All light-mode
+tokens are paired with a dark-mode counterpart (prefixed \`dark-\`)
+activated via \`prefers-color-scheme: dark\` or \`:root[data-theme="dark"]\`.
+
+- Neutral surfaces: \`bg\`, \`fg\`, \`muted-fg\`, \`text-high-contrast\`.
+- Brand: \`primary\` for brand badge, \`btn-primary-bg\` / \`btn-primary-fg\`
+  for primary calls-to-action. \`btn-primary-bg\` is tuned darker than a
+  default Tailwind blue to pass WCAG AA on white.
+- Semantic: \`success\`, \`error\`, \`favorite-color\`, \`important\`, plus
+  paired \`-bg\` / \`-text\` / \`-border\` tokens for badges and callouts.
+- Calculator states: \`calc-ok\` / \`calc-warn\` / \`calc-orange\` / \`calc-danger\`
+  / \`calc-dark\` map to the semantic palette.
+
+Tokens that rely on runtime alpha or \`color-mix()\` (borders, shadows,
+hover layers) are intentionally not represented as YAML tokens because
+DESIGN.md requires literal \`#HEX\` values. Treat them as implementation
+details of the CSS, not as part of the design contract. See
+\`web/styles/partials/variables.css\` and \`theme.css\` for the actual
+definitions.
+
+## Typography
+
+The web uses a single family, **Work Sans**, with a system-font fallback
+stack. The type scale is a Major Third (1.25) progression from 12 px
+caption to 48 px display. Weights run 400 / 500 / 600 / 700 / 800;
+600 is the default for headings. Line heights are tight on display
+copy (1.1-1.25) and relaxed on body (1.5).
+
+The \`typography\` tokens in the YAML front matter are semantic levels
+(\`display\`, \`h1\`..\`h4\`, \`body-lg\`..\`body-sm\`, \`caption\`) composed
+from the atomic \`--text-*\`, \`--font-*\`, and \`--leading-*\` primitives
+in \`variables.css\`.
+
+## Layout
+
+Spacing follows a 4 px base unit: \`space-1\` (4 px) through \`space-16\`
+(64 px). The scale is not linear - it skips through Fibonacci-adjacent
+steps (1, 2, 3, 4, 5, 6, 8, 10, 12, 16) to keep composition rhythmic.
+
+Layouts are content-first, single-column on mobile, with a centered
+max-width on desktop. The header uses a sticky translucent surface
+(\`color-mix\` over \`bg\`); the footer uses a lightly tinted surface
+(\`color-mix\` over \`bg\` at ~90%).
+
+## Elevation & Depth
+
+Elevation is the combination of a \`color-mix\` surface tint and a
+stacked \`box-shadow\` (inset highlight plus outer drop). It is not
+tokenized; the three tiers below live directly in
+\`web/styles/partials/theme.css\` and \`components.css\`, not in YAML:
+
+- Resting cards: subtle ~8 px blur at low alpha over a lightly tinted
+  surface (\`color-mix(in oklab, var(--bg) 88%, white 12%)\` in dark
+  mode, \`var(--bg)\` in light mode).
+- Floating surfaces (dropdowns, modals): 20-24 px blur at higher alpha
+  over the same tinted surface, with a 1 px inset highlight.
+- High-contrast mode: elevations collapse to 2 px solid borders via
+  \`prefers-contrast: more\` or \`:root[data-contrast="more"]\`; shadows
+  are effectively dropped.
+
+## Shapes
+
+Corner radii use a five-level scale, exposed as the \`rounded\` tokens
+in the YAML front matter: \`sm\` 4 px, \`md\` 6 px, \`lg\` 8 px, \`xl\` 12 px,
+\`full\` 9999 px (pill). Buttons use \`md\`, cards and modals use \`lg\`,
+the brand badge uses \`full\`. There is no "none" level: zero radius is
+a deliberate choice, not a token.
+
+## Components
+
+The \`components\` section in the YAML front matter assigns color and
+shape tokens to the core shipped components. It is not exhaustive - it
+covers the primitives that agents most often need to reproduce
+(buttons, cards, inputs, modal, brand badge, blockquote, pagination,
+and the calculator state pills). Dark-mode overrides are handled in
+\`theme.css\`; agents should assume any component is theme-aware and
+use the \`dark-*\` color tokens for dark surfaces.
+
+## Do's and Don'ts
+
+- Do keep type doing the heavy lifting. Chrome should be quiet.
+- Do use semantic color tokens (\`success-*\`, \`error-*\`, etc.) - never
+  raw hex in components.
+- Do keep contrast at WCAG AA or better. The token values already pass;
+  reach for them, not "close enough" shades.
+- Don't introduce Material Design 3 components or styles. Stitch will
+  default to MD3; steer it with this DESIGN.md and discard MD3-specific
+  output.
+- Don't ship emojis in UI copy - ESLint and markdownlint both reject
+  them repo-wide.
+- Don't use inline styles. \`html-validate\` blocks them; put styles in
+  the relevant partial under \`web/styles/partials/\`.
+- Don't edit the YAML front matter by hand. It is regenerated from
+  \`variables.css\` by \`npm run design:sync\` in the \`web\` workspace.
+
+## Workflow
+
+This DESIGN.md is the single source of truth for agents (Cursor,
+Claude, Stitch, Figma). The authoritative values live in
+\`web/styles/partials/variables.css\`. The sync script
+\`web/scripts/sync-design-tokens.ts\` parses that file and regenerates
+the YAML front matter above; it does not touch this Markdown body.
+
+- **Change a color or spacing value:** edit \`variables.css\`, then run
+  \`npm --prefix web run design:sync\`. CI enforces no drift via
+  \`npm run design:check\` in \`ci:web\`.
+- **Change a typography level, component contract, or radius scale:**
+  edit the constants at the top of \`sync-design-tokens.ts\` and re-run
+  \`design:sync\`. These are semantic decisions that do not have a 1:1
+  representation in CSS.
+- **Use Stitch for ideation:** seed Stitch with this file. Keep
+  generated mockups in \`web/.stitch/\` (gitignored). Do not ship
+  Stitch-generated HTML/CSS; translate mockups by hand into the
+  vanilla-TS components under \`web/src/components/\`.
+- **Validate:** \`npm --prefix web run design:check\` runs
+  \`design:sync --check\` for drift and \`@google/design.md lint\` for
+  structural correctness and WCAG contrast.
+`;
+
+export interface BuildInput {
+  existingContent?: string | undefined;
+  parsed: ClassifiedTokens;
+}
+
+const FRONT_MATTER_RE = /^---\n([\s\S]*?)\n---\n?([\s\S]*)$/;
+
+export function extractBody(existingContent: string | undefined): string {
+  if (existingContent === undefined) {
+    return DEFAULT_BODY;
+  }
+  const match = existingContent.match(FRONT_MATTER_RE);
+  if (!match) {
+    return existingContent.length > 0 ? existingContent : DEFAULT_BODY;
+  }
+  const body = match[2] ?? '';
+  return body.length > 0 ? body : DEFAULT_BODY;
+}
+
+export function buildDesignMd(input: BuildInput): string {
+  const yaml = renderFrontMatter(input.parsed);
+  const body = extractBody(input.existingContent);
+  return `---\n${yaml}---\n${body}`;
+}
+
+export interface RunOptions {
+  check: boolean;
+  variablesCssPath: string;
+  designMdPath: string;
+  readFile: (p: string) => string;
+  existsFile: (p: string) => boolean;
+  writeFile: (p: string, contents: string) => void;
+  logger: Pick<Console, 'log' | 'error'>;
+}
+
+export function run(options: RunOptions): 0 | 1 {
+  const cssContent = options.readFile(options.variablesCssPath);
+  const vars = parseCssVariables(cssContent);
+  const parsed = classifyTokens(vars);
+  const existing = options.existsFile(options.designMdPath)
+    ? options.readFile(options.designMdPath)
+    : undefined;
+  const next = buildDesignMd({ existingContent: existing, parsed });
+
+  if (options.check) {
+    if (existing !== next) {
+      options.logger.error(
+        'DESIGN.md is out of sync with web/styles/partials/variables.css. Run: npm --prefix web run design:sync',
+      );
+      return 1;
+    }
+    options.logger.log('DESIGN.md is in sync with variables.css.');
+    return 0;
+  }
+
+  options.writeFile(options.designMdPath, next);
+  options.logger.log(`Wrote ${options.designMdPath}`);
+  return 0;
+}
+
+function isMain(): boolean {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return import.meta.url === new URL(`file://${entry}`).href;
+  } catch {
+    return false;
+  }
+}
+
+if (isMain()) {
+  const check = process.argv.includes('--check');
+  const code = run({
+    check,
+    variablesCssPath: VARIABLES_CSS_PATH,
+    designMdPath: DESIGN_MD_PATH,
+    readFile: (p) => fs.readFileSync(p, 'utf8'),
+    existsFile: (p) => fs.existsSync(p),
+    writeFile: (p, c) => fs.writeFileSync(p, c, 'utf8'),
+    logger: console,
+  });
+  process.exit(code);
+}

--- a/web/tests/design-md-lint.test.ts
+++ b/web/tests/design-md-lint.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isIgnorableWarning,
+  isWcagFailureWarning,
+  runDesignMdLint,
+  type RunLintOptions,
+} from '../scripts/design-md-lint.ts';
+
+interface IgnorableLocalThis {
+  finding?: Parameters<typeof isIgnorableWarning>[0];
+  result?: boolean;
+}
+
+interface RunLintLocalThis {
+  stdout?: string;
+  stderr?: string;
+  status?: number | null;
+  lastArgs?: string[];
+  logs?: string[];
+  errors?: string[];
+  options?: RunLintOptions;
+  code?: 0 | 1;
+}
+
+function buildRunLintLocalThis(
+  stdout: string,
+  status: number | null = 0,
+): RunLintLocalThis {
+  const localThis: RunLintLocalThis = {};
+  localThis.stdout = stdout;
+  localThis.stderr = '';
+  localThis.status = status;
+  localThis.logs = [];
+  localThis.errors = [];
+  localThis.options = {
+    designMdPath: '/virt/DESIGN.md',
+    packageSpec: '@google/design.md@0.1.1',
+    runner: (args: string[]) => {
+      localThis.lastArgs = args;
+      return {
+        status: localThis.status === undefined ? 0 : localThis.status,
+        stdout: localThis.stdout ?? '',
+        stderr: localThis.stderr ?? '',
+      };
+    },
+    logger: {
+      log: (...args: unknown[]): void => {
+        localThis.logs!.push(args.map((a) => String(a)).join(' '));
+      },
+      error: (...args: unknown[]): void => {
+        localThis.errors!.push(args.map((a) => String(a)).join(' '));
+      },
+    },
+  };
+  return localThis;
+}
+
+describe('isIgnorableWarning', () => {
+  it('ignores "defined but never referenced by any component" warnings', () => {
+    const localThis: IgnorableLocalThis = {};
+    localThis.finding = {
+      severity: 'warning',
+      path: 'colors.dark-error-bg',
+      message: "'dark-error-bg' is defined but never referenced by any component.",
+    };
+    localThis.result = isIgnorableWarning(localThis.finding);
+
+    expect(localThis.result).toBe(true);
+  });
+
+  it('does not ignore other warnings', () => {
+    const localThis: IgnorableLocalThis = {};
+    localThis.finding = {
+      severity: 'warning',
+      path: 'components.btn-primary',
+      message: 'textColor (#fff) on backgroundColor (#ccc) fails WCAG AA.',
+    };
+    localThis.result = isIgnorableWarning(localThis.finding);
+
+    expect(localThis.result).toBe(false);
+  });
+
+  it('never treats errors as ignorable', () => {
+    const localThis: IgnorableLocalThis = {};
+    localThis.finding = {
+      severity: 'error',
+      message: 'is defined but never referenced by any component',
+    };
+    localThis.result = isIgnorableWarning(localThis.finding);
+
+    expect(localThis.result).toBe(false);
+  });
+
+  it('never treats infos as ignorable warnings', () => {
+    const localThis: IgnorableLocalThis = {};
+    localThis.finding = {
+      severity: 'info',
+      message: 'something is defined but never referenced by any component',
+    };
+    localThis.result = isIgnorableWarning(localThis.finding);
+
+    expect(localThis.result).toBe(false);
+  });
+});
+
+describe('isWcagFailureWarning', () => {
+  it('detects "below WCAG AA" contrast-ratio warnings', () => {
+    const localThis: IgnorableLocalThis = {};
+    localThis.finding = {
+      severity: 'warning',
+      path: 'components.btn-primary',
+      message:
+        'textColor (#fff) on backgroundColor (#ccc) has contrast ratio 3.1:1, below WCAG AA minimum of 4.5:1.',
+    };
+    localThis.result = isWcagFailureWarning(localThis.finding);
+
+    expect(localThis.result).toBe(true);
+  });
+
+  it('detects AAA-level contrast failures too', () => {
+    const localThis: IgnorableLocalThis = {};
+    localThis.finding = {
+      severity: 'warning',
+      message: 'contrast 5:1, below WCAG AAA threshold.',
+    };
+    localThis.result = isWcagFailureWarning(localThis.finding);
+
+    expect(localThis.result).toBe(true);
+  });
+
+  it('does not flag passing or unrelated warnings', () => {
+    const localThis: IgnorableLocalThis = {};
+    localThis.finding = {
+      severity: 'warning',
+      message: "'primary' is defined but never referenced by any component.",
+    };
+    localThis.result = isWcagFailureWarning(localThis.finding);
+
+    expect(localThis.result).toBe(false);
+  });
+
+  it('does not flag error-severity findings (they already fail)', () => {
+    const localThis: IgnorableLocalThis = {};
+    localThis.finding = {
+      severity: 'error',
+      message: 'below WCAG AA',
+    };
+    localThis.result = isWcagFailureWarning(localThis.finding);
+
+    expect(localThis.result).toBe(false);
+  });
+});
+
+describe('runDesignMdLint', () => {
+  it('returns 0 when there are only ignored warnings and infos', () => {
+    const report = {
+      findings: [
+        {
+          severity: 'warning',
+          path: 'colors.dark-bg-primary',
+          message: "'dark-bg-primary' is defined but never referenced by any component.",
+        },
+        { severity: 'info', message: 'Design system defines 52 colors.' },
+      ],
+      summary: { errors: 0, warnings: 1, infos: 1 },
+    };
+    const localThis = buildRunLintLocalThis(JSON.stringify(report));
+
+    localThis.code = runDesignMdLint(localThis.options!);
+
+    expect(localThis.code).toBe(0);
+    expect(localThis.errors!.length).toBe(0);
+    expect(localThis.logs!.some((l) => l.startsWith('info  '))).toBe(true);
+    expect(
+      localThis.logs!.some((l) =>
+        l.includes('0 error(s), 0 warning(s), 1 ignored-warning(s)'),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns 1 and logs errors when the linter reports structural errors', () => {
+    const report = {
+      findings: [
+        {
+          severity: 'error',
+          path: 'colors.primary',
+          message: "Invalid color value 'oops'.",
+        },
+      ],
+      summary: { errors: 1, warnings: 0, infos: 0 },
+    };
+    const localThis = buildRunLintLocalThis(JSON.stringify(report));
+
+    localThis.code = runDesignMdLint(localThis.options!);
+
+    expect(localThis.code).toBe(1);
+    expect(
+      localThis.errors!.some((e) => e.includes("Invalid color value 'oops'")),
+    ).toBe(true);
+  });
+
+  it('surfaces non-ignorable non-WCAG warnings without failing the run', () => {
+    const report = {
+      findings: [
+        {
+          severity: 'warning',
+          path: 'colors.primary',
+          message: "'primary' uses an unusual color-space annotation.",
+        },
+      ],
+      summary: { errors: 0, warnings: 1, infos: 0 },
+    };
+    const localThis = buildRunLintLocalThis(JSON.stringify(report));
+
+    localThis.code = runDesignMdLint(localThis.options!);
+
+    expect(localThis.code).toBe(0);
+    expect(
+      localThis.logs!.some(
+        (l) => l.startsWith('warn  ') && l.includes('color-space'),
+      ),
+    ).toBe(true);
+  });
+
+  it('promotes WCAG-failure warnings to errors and fails the run', () => {
+    const report = {
+      findings: [
+        {
+          severity: 'warning',
+          path: 'components.btn-primary',
+          message:
+            'textColor (#ffffff) on backgroundColor (#aaccff) has contrast ratio 1.64:1, below WCAG AA minimum of 4.5:1.',
+        },
+      ],
+      summary: { errors: 0, warnings: 1, infos: 0 },
+    };
+    const localThis = buildRunLintLocalThis(JSON.stringify(report));
+
+    localThis.code = runDesignMdLint(localThis.options!);
+
+    expect(localThis.code).toBe(1);
+    expect(
+      localThis.errors!.some(
+        (e) => e.includes('below WCAG AA') && e.includes('promoted from warning'),
+      ),
+    ).toBe(true);
+  });
+
+  it('forwards the expected argv to the upstream package via the runner', () => {
+    const report = { findings: [], summary: { errors: 0, warnings: 0, infos: 0 } };
+    const localThis = buildRunLintLocalThis(JSON.stringify(report));
+
+    runDesignMdLint(localThis.options!);
+
+    expect(localThis.lastArgs).toEqual([
+      '--yes',
+      '@google/design.md@0.1.1',
+      'lint',
+      '--format',
+      'json',
+      '/virt/DESIGN.md',
+    ]);
+  });
+
+  it('fails with a helpful error when the upstream command cannot run', () => {
+    const localThis = buildRunLintLocalThis('', null);
+    localThis.stderr = 'spawn npx ENOENT';
+
+    localThis.code = runDesignMdLint(localThis.options!);
+
+    expect(localThis.code).toBe(1);
+    expect(
+      localThis.errors!.some((e) => e.includes('design.md lint failed to run')),
+    ).toBe(true);
+  });
+
+  it('fails with a parse error when the upstream command emits non-JSON output', () => {
+    const localThis = buildRunLintLocalThis('not json at all');
+
+    localThis.code = runDesignMdLint(localThis.options!);
+
+    expect(localThis.code).toBe(1);
+    expect(
+      localThis.errors!.some((e) =>
+        e.includes('Could not parse design.md lint output as JSON'),
+      ),
+    ).toBe(true);
+  });
+
+  it('treats upstream exit code > 1 as runtime failure', () => {
+    const localThis = buildRunLintLocalThis('', 2);
+    localThis.stderr = 'panic';
+
+    localThis.code = runDesignMdLint(localThis.options!);
+
+    expect(localThis.code).toBe(1);
+    expect(
+      localThis.errors!.some((e) => e.includes('design.md lint failed to run')),
+    ).toBe(true);
+  });
+});

--- a/web/tests/sync-design-tokens.test.ts
+++ b/web/tests/sync-design-tokens.test.ts
@@ -1,0 +1,330 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseCssVariables,
+  classifyTokens,
+  renderFrontMatter,
+  buildDesignMd,
+  extractBody,
+  run,
+  type ClassifiedTokens,
+  type RunOptions,
+} from '../scripts/sync-design-tokens.ts';
+
+interface ParseLocalThis {
+  css?: string;
+  parsed?: Map<string, string>;
+}
+
+interface ClassifyLocalThis {
+  vars?: Map<string, string>;
+  classified?: ClassifiedTokens;
+}
+
+interface RenderLocalThis {
+  parsed?: ClassifiedTokens;
+  yaml?: string;
+}
+
+interface RunLocalThis {
+  files?: Map<string, string>;
+  written?: Map<string, string>;
+  logs?: string[];
+  errors?: string[];
+  options?: RunOptions;
+  code?: 0 | 1;
+}
+
+function sampleCss(): string {
+  return `:root {
+  /* Spacing scale */
+  --space-1: 0.25rem;   /* 4px */
+  --space-4: 1rem;      /* 16px */
+  --space-16: 4rem;     /* 64px */
+
+  /* Colors - hex OK */
+  --bg: #fff;
+  --fg: #111827;
+  --primary: #030213;
+
+  /* Color - rgba is intentionally ignored (DESIGN.md requires #HEX) */
+  --border: rgb(0 0 0 / 25%);
+
+  /* Color - color-mix / var refs are ignored */
+  --hover: color-mix(in oklab, var(--bg) 90%, black 10%);
+  --other: var(--bg);
+
+  /* Typography primitives - not color, not space-*, classified elsewhere */
+  --text-xs: 0.75rem;
+  --font-normal: 400;
+}`;
+}
+
+function buildRunLocalThis(initialFiles: Record<string, string> = {}): RunLocalThis {
+  const localThis: RunLocalThis = {};
+  localThis.files = new Map(Object.entries(initialFiles));
+  localThis.written = new Map();
+  localThis.logs = [];
+  localThis.errors = [];
+  localThis.options = {
+    check: false,
+    variablesCssPath: '/virt/variables.css',
+    designMdPath: '/virt/DESIGN.md',
+    readFile: (p: string): string => {
+      const value = localThis.files!.get(p);
+      if (value === undefined) {
+        throw new Error(`readFile missing: ${p}`);
+      }
+      return value;
+    },
+    existsFile: (p: string): boolean => localThis.files!.has(p),
+    writeFile: (p: string, contents: string): void => {
+      localThis.written!.set(p, contents);
+      localThis.files!.set(p, contents);
+    },
+    logger: {
+      log: (...args: unknown[]): void => {
+        localThis.logs!.push(args.map((a) => String(a)).join(' '));
+      },
+      error: (...args: unknown[]): void => {
+        localThis.errors!.push(args.map((a) => String(a)).join(' '));
+      },
+    },
+  };
+  return localThis;
+}
+
+describe('parseCssVariables', () => {
+  it('extracts --name: value pairs from :root block', () => {
+    const localThis: ParseLocalThis = {};
+    localThis.css = sampleCss();
+    localThis.parsed = parseCssVariables(localThis.css);
+
+    expect(localThis.parsed.get('space-1')).toBe('0.25rem');
+    expect(localThis.parsed.get('space-4')).toBe('1rem');
+    expect(localThis.parsed.get('space-16')).toBe('4rem');
+    expect(localThis.parsed.get('bg')).toBe('#fff');
+    expect(localThis.parsed.get('fg')).toBe('#111827');
+    expect(localThis.parsed.get('border')).toBe('rgb(0 0 0 / 25%)');
+    expect(localThis.parsed.get('hover')).toBe(
+      'color-mix(in oklab, var(--bg) 90%, black 10%)',
+    );
+  });
+
+  it('strips /* ... */ comments so they cannot be misread as declarations', () => {
+    const localThis: ParseLocalThis = {};
+    localThis.css =
+      ':root {\n  /* --fake: #000; */\n  --real: #abc;\n}';
+    localThis.parsed = parseCssVariables(localThis.css);
+
+    expect(localThis.parsed.has('fake')).toBe(false);
+    expect(localThis.parsed.get('real')).toBe('#abc');
+  });
+
+  it('returns an empty map when there is no :root block', () => {
+    const localThis: ParseLocalThis = {};
+    localThis.css = 'body { color: red; }';
+    localThis.parsed = parseCssVariables(localThis.css);
+
+    expect(localThis.parsed.size).toBe(0);
+  });
+});
+
+describe('classifyTokens', () => {
+  it('keeps only hex colors, normalizing shorthand, and rejects rgba / color-mix / var refs', () => {
+    const localThis: ClassifyLocalThis = {};
+    localThis.vars = parseCssVariables(sampleCss());
+    localThis.classified = classifyTokens(localThis.vars);
+
+    expect(localThis.classified.colors.get('bg')).toBe('#ffffff');
+    expect(localThis.classified.colors.get('fg')).toBe('#111827');
+    expect(localThis.classified.colors.get('primary')).toBe('#030213');
+    expect(localThis.classified.colors.has('border')).toBe(false);
+    expect(localThis.classified.colors.has('hover')).toBe(false);
+    expect(localThis.classified.colors.has('other')).toBe(false);
+    expect(localThis.classified.colors.has('text-xs')).toBe(false);
+    expect(localThis.classified.colors.has('font-normal')).toBe(false);
+  });
+
+  it('emits spacing values in px, converting from rem via 16px base', () => {
+    const localThis: ClassifyLocalThis = {};
+    localThis.vars = parseCssVariables(sampleCss());
+    localThis.classified = classifyTokens(localThis.vars);
+
+    expect(localThis.classified.spacing.get('1')).toBe('4px');
+    expect(localThis.classified.spacing.get('4')).toBe('16px');
+    expect(localThis.classified.spacing.get('16')).toBe('64px');
+  });
+
+  it('accepts px values directly in --space-* and preserves them', () => {
+    const localThis: ClassifyLocalThis = {};
+    localThis.vars = new Map([['space-2', '8px']]);
+    localThis.classified = classifyTokens(localThis.vars);
+
+    expect(localThis.classified.spacing.get('2')).toBe('8px');
+  });
+
+  it('drops --space-* values in unsupported units (e.g. em)', () => {
+    const localThis: ClassifyLocalThis = {};
+    localThis.vars = new Map([['space-3', '1em']]);
+    localThis.classified = classifyTokens(localThis.vars);
+
+    expect(localThis.classified.spacing.has('3')).toBe(false);
+  });
+});
+
+describe('renderFrontMatter', () => {
+  it('emits a stable, DESIGN.md-shaped YAML front matter', () => {
+    const localThis: RenderLocalThis = {};
+    localThis.parsed = classifyTokens(parseCssVariables(sampleCss()));
+    localThis.yaml = renderFrontMatter(localThis.parsed);
+
+    expect(localThis.yaml.startsWith('version: alpha\n')).toBe(true);
+    expect(localThis.yaml).toContain('name: "Murphy\'s Law Archive"');
+    expect(localThis.yaml).toContain('colors:');
+    expect(localThis.yaml).toContain('  bg: "#ffffff"');
+    expect(localThis.yaml).toContain('  primary: "#030213"');
+    expect(localThis.yaml).toContain('typography:');
+    expect(localThis.yaml).toContain('  display:');
+    expect(localThis.yaml).toContain('rounded:');
+    expect(localThis.yaml).toContain('  full: "9999px"');
+    expect(localThis.yaml).toContain('spacing:');
+    expect(localThis.yaml).toContain('  "1": "4px"');
+    expect(localThis.yaml).toContain('components:');
+    expect(localThis.yaml).toContain('  btn-primary:');
+    expect(localThis.yaml).toContain(
+      '    backgroundColor: "{colors.btn-primary-bg}"',
+    );
+  });
+
+  it('appends author-added colors alphabetically after the canonical order', () => {
+    const localThis: RenderLocalThis = {};
+    localThis.parsed = {
+      colors: new Map([
+        ['bg', '#ffffff'],
+        ['zeta-extra', '#123456'],
+        ['alpha-extra', '#654321'],
+      ]),
+      spacing: new Map(),
+    };
+    localThis.yaml = renderFrontMatter(localThis.parsed);
+
+    const idxBg = localThis.yaml.indexOf('  bg: ');
+    const idxAlpha = localThis.yaml.indexOf('  alpha-extra: ');
+    const idxZeta = localThis.yaml.indexOf('  zeta-extra: ');
+    expect(idxBg).toBeGreaterThanOrEqual(0);
+    expect(idxAlpha).toBeGreaterThan(idxBg);
+    expect(idxZeta).toBeGreaterThan(idxAlpha);
+  });
+
+  it('quotes YAML keys that are not safe bare identifiers', () => {
+    const localThis: RenderLocalThis = {};
+    localThis.parsed = {
+      colors: new Map(),
+      spacing: new Map([['1', '4px']]),
+    };
+    localThis.yaml = renderFrontMatter(localThis.parsed);
+
+    expect(localThis.yaml).toContain('  "1": "4px"');
+  });
+});
+
+describe('extractBody', () => {
+  it('falls back to the default body when no file exists', () => {
+    expect(extractBody(undefined)).toContain("# Murphy's Law Archive");
+  });
+
+  it('falls back to the default body when the YAML block is empty/missing', () => {
+    expect(extractBody('')).toContain("# Murphy's Law Archive");
+  });
+
+  it('returns the body unchanged when front matter is present', () => {
+    const file = '---\nversion: alpha\n---\n# Custom body\n\nHello.';
+    expect(extractBody(file)).toBe('# Custom body\n\nHello.');
+  });
+
+  it('returns existing content as-is when it has no front matter', () => {
+    const file = '# Just a body\n\nNo front matter here.';
+    expect(extractBody(file)).toBe('# Just a body\n\nNo front matter here.');
+  });
+});
+
+describe('buildDesignMd', () => {
+  it('glues front matter and preserved body with the expected delimiters', () => {
+    const parsed = classifyTokens(parseCssVariables(sampleCss()));
+    const existing = '---\nversion: old\n---\n# Preserved\n';
+    const next = buildDesignMd({ existingContent: existing, parsed });
+
+    expect(next.startsWith('---\nversion: alpha\n')).toBe(true);
+    expect(next).toMatch(/\n---\n# Preserved\n$/);
+  });
+});
+
+describe('run', () => {
+  it('writes DESIGN.md on first run when the file is missing', () => {
+    const localThis = buildRunLocalThis({
+      '/virt/variables.css': sampleCss(),
+    });
+    localThis.options!.check = false;
+
+    localThis.code = run(localThis.options!);
+
+    expect(localThis.code).toBe(0);
+    expect(localThis.written!.has('/virt/DESIGN.md')).toBe(true);
+    expect(localThis.written!.get('/virt/DESIGN.md')!.startsWith('---\n')).toBe(true);
+    expect(localThis.logs!.some((l) => l.includes('Wrote /virt/DESIGN.md'))).toBe(
+      true,
+    );
+  });
+
+  it('in --check mode returns 0 when the file is already in sync', () => {
+    const initial = buildRunLocalThis({ '/virt/variables.css': sampleCss() });
+    run(initial.options!);
+
+    const localThis = buildRunLocalThis({
+      '/virt/variables.css': sampleCss(),
+      '/virt/DESIGN.md': initial.written!.get('/virt/DESIGN.md')!,
+    });
+    localThis.options!.check = true;
+    localThis.code = run(localThis.options!);
+
+    expect(localThis.code).toBe(0);
+    expect(localThis.written!.size).toBe(0);
+    expect(
+      localThis.logs!.some((l) => l.includes('DESIGN.md is in sync')),
+    ).toBe(true);
+  });
+
+  it('in --check mode returns 1 and logs an error when the file is out of sync', () => {
+    const localThis = buildRunLocalThis({
+      '/virt/variables.css': sampleCss(),
+      '/virt/DESIGN.md': '---\nversion: alpha\n---\n# stale\n',
+    });
+    localThis.options!.check = true;
+
+    localThis.code = run(localThis.options!);
+
+    expect(localThis.code).toBe(1);
+    expect(
+      localThis.errors!.some((e) =>
+        e.includes('DESIGN.md is out of sync'),
+      ),
+    ).toBe(true);
+    expect(localThis.written!.size).toBe(0);
+  });
+
+  it('in write mode rewrites the front matter while preserving the body', () => {
+    const localThis = buildRunLocalThis({
+      '/virt/variables.css': sampleCss(),
+      '/virt/DESIGN.md':
+        '---\nversion: old\nname: "stale"\n---\n# Kept body\n\nContent.\n',
+    });
+    localThis.options!.check = false;
+
+    localThis.code = run(localThis.options!);
+
+    const written = localThis.written!.get('/virt/DESIGN.md')!;
+    expect(localThis.code).toBe(0);
+    expect(written).toContain('version: alpha');
+    expect(written).toMatch(/\n---\n# Kept body\n\nContent\.\n$/);
+  });
+});


### PR DESCRIPTION
## Summary

- Author `web/DESIGN.md` using Google Labs' open-source [DESIGN.md](https://github.com/google-labs-code/design.md) format. YAML front matter holds 52 colors / 9 typography levels / 5 rounding tokens / 10 spacing tokens / 15 component contracts; the Markdown body covers tone, a11y posture, elevation, shapes, and the Stitch workflow.
- Add `web/scripts/sync-design-tokens.ts` (parses `variables.css`, regenerates the YAML front matter, preserves the authored body, supports `--check` for CI) and `web/scripts/design-md-lint.ts` (wraps `@google/design.md lint` and **promotes WCAG-AA contrast warnings to errors** so sub-threshold pairs fail the build).
- Wire `npm run design:check` into `ci:web` between `lint:html` and `npm test`. Drift between `variables.css` and `DESIGN.md` now fails CI.
- Add 35 vitest cases across `tests/sync-design-tokens.test.ts` and `tests/design-md-lint.test.ts` (localThis pattern, no test bypasses).
- Pin `@google/design.md@0.1.1` as a web devDependency. Gitignore `web/.stitch/` so Stitch-generated mockups never ship.
- Bump root `2.4.6 -> 2.4.7` and web `3.2.3 -> 3.2.4` (patch).

**Explicitly not shipping**: Stitch-generated HTML/CSS, Material Design 3 classes, any change to iOS/Android, or any visual change. This PR only formalizes what is already in `variables.css` and `theme.css`.

## Test plan

- [ ] `npm run ci:web` passes end-to-end (typecheck, eslint, stylelint, html-validate, `design:check`, vitest, vite build + SSG).
- [ ] `cd web && npm run design:check` reports `0 error(s), 0 warning(s), 36 ignored-warning(s), 1 info(s)`.
- [ ] `cd web && npm run test:coverage` stays above the 95 / 92 gates (measured: 98.83 / 95.15 / 96.87 / 99.12).
- [ ] Drift probe: edit any color in `web/styles/partials/variables.css`, run `npm run design:check` in `web/`, confirm exit 1 with "DESIGN.md is out of sync"; run `npm run design:sync`, confirm only that YAML key changed in `web/DESIGN.md`.
- [ ] WCAG probe: set `--btn-primary-bg: #aaccff;` in `variables.css`, `npm run design:sync`, `npm run design:check`; confirm exit 1 with `textColor (#ffffff) on backgroundColor (#aaccff) has contrast ratio 1.64:1, below WCAG AA minimum of 4.5:1. (promoted from warning: WCAG AA is a hard gate)`. Revert.
- [ ] `markdownlint-cli2 CHANGELOG.md web/DESIGN.md` shows 0 errors.
- [ ] No safeguard bypasses in the history of this branch (`git log --oneline origin/main..HEAD` shows one commit, no `--no-verify`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ravidorr/murphys-laws/84)
<!-- Reviewable:end -->
