### PR TITLE
feat(web): expand DESIGN.md components to cover chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Five more chrome components in the `COMPONENTS` contract driven by [web/scripts/sync-design-tokens.ts](web/scripts/sync-design-tokens.ts): `notification`, `header`, `footer`, `breadcrumb`, `search-autocomplete`. These are the pieces AI agents most often regenerate without consulting the design contract, so pinning them as explicit token references in `web/DESIGN.md`'s YAML front matter makes the contract binding on those surfaces too. Component count 16 -> 21; ignored-warning count 35 -> 34 (`muted-fg` is now referenced by `footer` / `breadcrumb` so it drops out of the unreferenced bucket). Translucent backgrounds on `header` and floating surfaces remain intentionally untokenized (see "Elevation & Depth" in the Markdown body) because DESIGN.md requires literal `#HEX`. One new vitest case asserts presence of each new component.
+
+### Added
 - `web/DESIGN.md`: adopted Google Labs' [DESIGN.md](https://github.com/google-labs-code/design.md) format as the web's design-system contract. YAML front matter (52 colors, 9 typography levels, 5 rounding tokens, 10 spacing tokens, 15 components) is regenerated from `web/styles/partials/variables.css` by `web/scripts/sync-design-tokens.ts`; the Markdown body is authored (tone, a11y posture, elevation, shapes, workflow). New `npm run design:check` in `web/` runs drift detection plus `@google/design.md lint` and is wired into `ci:web`; WCAG-AA contrast failures are promoted from warnings to errors so sub-threshold pairs fail the build. Stitch-generated mockups live in `web/.stitch/` (gitignored) and are never shipped. Adds 35 vitest cases and pins `@google/design.md@0.1.1` as a web devDependency.
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murphys-laws-monorepo",
-      "version": "2.4.10",
+      "version": "2.4.11",
       "license": "CC0-1.0",
       "workspaces": [
         "backend",
@@ -16252,7 +16252,7 @@
     },
     "web": {
       "name": "murphys-laws-web",
-      "version": "3.2.7",
+      "version": "3.2.8",
       "license": "CC0-1.0",
       "dependencies": {
         "@sentry/browser": "^10.25.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.4.10",
+  "version": "2.4.11",
   "description": "Murphy's Laws - Monorepo for Web, iOS, and Android apps",
   "private": true,
   "workspaces": [

--- a/web/DESIGN.md
+++ b/web/DESIGN.md
@@ -181,6 +181,25 @@ components:
     textColor: "{colors.text-high-contrast}"
     typography: "{typography.body-md}"
     width: "24px"
+  notification:
+    backgroundColor: "{colors.bg}"
+    textColor: "{colors.fg}"
+    rounded: "{rounded.lg}"
+    typography: "{typography.body-sm}"
+  header:
+    textColor: "{colors.fg}"
+    typography: "{typography.body-md}"
+  footer:
+    textColor: "{colors.muted-fg}"
+    typography: "{typography.body-sm}"
+  breadcrumb:
+    textColor: "{colors.muted-fg}"
+    typography: "{typography.body-sm}"
+  search-autocomplete:
+    backgroundColor: "{colors.bg}"
+    textColor: "{colors.fg}"
+    rounded: "{rounded.lg}"
+    typography: "{typography.body-md}"
 ---
 # Murphy's Law Archive - Design System
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-web",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "description": "Murphy's Laws Web Application",
   "type": "module",
   "scripts": {

--- a/web/scripts/sync-design-tokens.ts
+++ b/web/scripts/sync-design-tokens.ts
@@ -285,6 +285,46 @@ const COMPONENTS: Record<string, Record<string, string>> = {
     typography: '{typography.body-md}',
     width: '24px',
   },
+  // Notification / toast. The shipped surface is always decorated with a
+  // success / error variant class (see web/styles/partials/notification.css);
+  // the base entry captures the shared shape (radius, type size) and uses
+  // neutral bg/fg as a placeholder. Agents should swap to success-bg / error-bg
+  // when rendering the concrete variants, matching the calc-* pattern above.
+  notification: {
+    backgroundColor: '{colors.bg}',
+    textColor: '{colors.fg}',
+    rounded: '{rounded.lg}',
+    typography: '{typography.body-sm}',
+  },
+  // Sticky header. The shipped background is a translucent color-mix over
+  // --bg; DESIGN.md's YAML schema only allows literal #HEX, so the background
+  // is deliberately omitted (see Elevation & Depth in the Markdown body).
+  header: {
+    textColor: '{colors.fg}',
+    typography: '{typography.body-md}',
+  },
+  // Site footer. Nav links use muted-fg by default and lift to fg on hover
+  // (see web/styles/partials/layout.css). Contract records the default.
+  footer: {
+    textColor: '{colors.muted-fg}',
+    typography: '{typography.body-sm}',
+  },
+  // Breadcrumb trail. The trail links are muted-fg; the current-page item is
+  // fg. Contract records the trail colour (dominant by count); current-page
+  // styling is a local emphasis override in components.css.
+  breadcrumb: {
+    textColor: '{colors.muted-fg}',
+    typography: '{typography.body-sm}',
+  },
+  // Search autocomplete dropdown (floating surface). Elevation / shadow are
+  // not tokenized (see Elevation & Depth); the entry captures the solid
+  // surface, text, radius, and type size.
+  'search-autocomplete': {
+    backgroundColor: '{colors.bg}',
+    textColor: '{colors.fg}',
+    rounded: '{rounded.lg}',
+    typography: '{typography.body-md}',
+  },
 };
 
 const NAME = "Murphy's Law Archive";

--- a/web/tests/sync-design-tokens.test.ts
+++ b/web/tests/sync-design-tokens.test.ts
@@ -196,6 +196,24 @@ describe('renderFrontMatter', () => {
     );
   });
 
+  it('includes the chrome components that AI agents most often regenerate', () => {
+    const localThis: RenderLocalThis = {};
+    localThis.parsed = classifyTokens(parseCssVariables(sampleCss()));
+    localThis.yaml = renderFrontMatter(localThis.parsed);
+
+    // Anchored on the two-space YAML indent so we match component keys
+    // (not stray substrings inside token refs like {colors.bg}).
+    expect(localThis.yaml).toContain('\n  notification:\n');
+    expect(localThis.yaml).toContain('\n  header:\n');
+    expect(localThis.yaml).toContain('\n  footer:\n');
+    expect(localThis.yaml).toContain('\n  breadcrumb:\n');
+    expect(localThis.yaml).toContain('\n  search-autocomplete:\n');
+
+    expect(localThis.yaml).toContain(
+      '  search-autocomplete:\n    backgroundColor: "{colors.bg}"\n    textColor: "{colors.fg}"\n    rounded: "{rounded.lg}"\n    typography: "{typography.body-md}"',
+    );
+  });
+
   it('appends author-added colors alphabetically after the canonical order', () => {
     const localThis: RenderLocalThis = {};
     localThis.parsed = {


### PR DESCRIPTION
## Summary

- Adds 5 chrome component contracts to the `COMPONENTS` constant in `web/scripts/sync-design-tokens.ts`: `notification`, `header`, `footer`, `breadcrumb`, `search-autocomplete`. These are the surfaces AI agents most often regenerate without consulting the design contract.
- `web/DESIGN.md` regenerated via `npm run design:sync`; component count `16 -> 21`. Translucent backgrounds on `header` and floating dropdowns remain intentionally untokenized (see "Elevation & Depth" in the body) because DESIGN.md's YAML front matter only allows literal `#HEX`.
- One new vitest case asserts presence of each new component in the rendered YAML. Test total `2641 -> 2642`.
- Ignored-warning count `35 -> 34` because `muted-fg` is now consumed by `footer` / `breadcrumb`.
- Closes Item 4 of the design-md follow-ups plan.

## Test plan

- [x] `npm --prefix web run design:sync` then `npm --prefix web run design:check` -> `0 error(s), 0 warning(s)`, `21 components`.
- [x] `npm run ci:web` -> all 91 test files / 2642 tests pass; typecheck, ESLint, Stylelint, html-validate, design:check, build all green.
- [ ] GitHub Actions CI green on the branch before marking ready.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ravidorr/murphys-laws/88)
<!-- Reviewable:end -->
