### PR TITLE
feat(web): export DESIGN.md tokens as DTCG JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,7 @@ web/dist/
 
 # Generated at build time by build:openapi
 web/public/openapi.json
+
+# On-demand DTCG exports of DESIGN.md (for designers importing into Figma / Style Dictionary).
+# Regenerate with `npm --prefix web run design:export`.
+web/.design-exports/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `npm --prefix web run design:export` emits the DESIGN.md token catalogue as a [Design Tokens Community Group (DTCG)](https://tr.designtokens.org/format/) JSON document at `web/.design-exports/design-tokens.dtcg.json` (gitignored). Designers can import the file into Figma Variables (via Tokens Studio or Figma's native JSON import) or feed it into Style Dictionary / any DTCG-aware pipeline without hand-translating `web/DESIGN.md`'s YAML. Output reuses the `parseCssVariables` + `classifyTokens` pipeline from [web/scripts/sync-design-tokens.ts](web/scripts/sync-design-tokens.ts), so the export can never drift from what `design:check` publishes. Nested shape: `color.*`, `dimension.spacing.*`, `dimension.radius.*`, `typography.*` (composite tokens), `component.*` (references into the base tokens). The export is intentionally NOT in `ci:web`; `design:check` remains the server-side gate. 22 new vitest cases cover the build / reference rewriting / type inference / run-mode behaviour.
+
+### Added
 - Five more chrome components in the `COMPONENTS` contract driven by [web/scripts/sync-design-tokens.ts](web/scripts/sync-design-tokens.ts): `notification`, `header`, `footer`, `breadcrumb`, `search-autocomplete`. These are the pieces AI agents most often regenerate without consulting the design contract, so pinning them as explicit token references in `web/DESIGN.md`'s YAML front matter makes the contract binding on those surfaces too. Component count 16 -> 21; ignored-warning count 35 -> 34 (`muted-fg` is now referenced by `footer` / `breadcrumb` so it drops out of the unreferenced bucket). Translucent backgrounds on `header` and floating surfaces remain intentionally untokenized (see "Elevation & Depth" in the Markdown body) because DESIGN.md requires literal `#HEX`. One new vitest case asserts presence of each new component.
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.4.11",
+  "version": "2.4.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murphys-laws-monorepo",
-      "version": "2.4.11",
+      "version": "2.4.12",
       "license": "CC0-1.0",
       "workspaces": [
         "backend",
@@ -16252,7 +16252,7 @@
     },
     "web": {
       "name": "murphys-laws-web",
-      "version": "3.2.8",
+      "version": "3.2.9",
       "license": "CC0-1.0",
       "dependencies": {
         "@sentry/browser": "^10.25.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.4.11",
+  "version": "2.4.12",
   "description": "Murphy's Laws - Monorepo for Web, iOS, and Android apps",
   "private": true,
   "workspaces": [

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-web",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "description": "Murphy's Laws Web Application",
   "type": "module",
   "scripts": {
@@ -23,7 +23,8 @@
     "optimize:images": "tsx scripts/optimize-images.ts",
     "optimize:images:dry-run": "tsx scripts/optimize-images.ts --dry-run",
     "design:sync": "tsx scripts/sync-design-tokens.ts",
-    "design:check": "tsx scripts/sync-design-tokens.ts --check && tsx scripts/design-md-lint.ts"
+    "design:check": "tsx scripts/sync-design-tokens.ts --check && tsx scripts/design-md-lint.ts",
+    "design:export": "tsx scripts/export-design-tokens.ts"
   },
   "keywords": [
     "murphys-law",

--- a/web/scripts/export-design-tokens.ts
+++ b/web/scripts/export-design-tokens.ts
@@ -1,0 +1,231 @@
+/**
+ * Export the design tokens defined by web/DESIGN.md (and its upstream source,
+ * web/styles/partials/variables.css) into a Design Tokens Community Group
+ * (DTCG) JSON file. The DTCG format is consumed by Figma Variables (via the
+ * Tokens Studio plugin or Figma's native JSON import), Style Dictionary,
+ * and most commercial design-to-code pipelines.
+ *
+ *   https://tr.designtokens.org/format/
+ *
+ * Output is a single JSON file. It is written to web/.design-exports/
+ * (gitignored) so designers can import it on demand without polluting the
+ * repo with a generated artifact. The script is intentionally NOT wired
+ * into `ci:web`; DESIGN.md remains the single source of truth that CI
+ * enforces. This is strictly an on-demand export.
+ *
+ * Reuses the parse + classify pipeline from sync-design-tokens.ts so the
+ * export can never drift from what DESIGN.md publishes.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  parseCssVariables,
+  classifyTokens,
+  TYPOGRAPHY_LEVELS,
+  ROUNDED_SCALE,
+  COMPONENTS,
+  type ClassifiedTokens,
+  type TypographyLevel,
+} from './sync-design-tokens.ts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const VARIABLES_CSS_PATH = path.resolve(
+  __dirname,
+  '../styles/partials/variables.css',
+);
+const DEFAULT_OUTPUT_PATH = path.resolve(
+  __dirname,
+  '../.design-exports/design-tokens.dtcg.json',
+);
+
+export interface DtcgLeafToken {
+  $value: string | number | Record<string, string | number>;
+  $type: string;
+  $description?: string;
+}
+
+export interface DtcgGroup {
+  [key: string]: DtcgLeafToken | DtcgGroup;
+}
+
+export interface DtcgDocument {
+  $schema: string;
+  $description: string;
+  color: DtcgGroup;
+  dimension: DtcgGroup;
+  typography: DtcgGroup;
+  component: DtcgGroup;
+}
+
+/**
+ * Build a DTCG-formatted document from the parsed design tokens and the
+ * semantic levels (typography, radius, components) owned by the sync script.
+ *
+ * The shape follows the spec:
+ *   - leaves carry both `$value` and `$type`
+ *   - groups nest by category (color, dimension, typography, component)
+ *   - token references use the dot path `{category.subgroup.name}` consistent
+ *     with DESIGN.md's existing `{colors.foo}` / `{rounded.md}` / `{typography.body-md}` syntax
+ *
+ * Component entries are preserved as references (not resolved to concrete
+ * values) so that consumers who import tokens into Figma Variables can wire
+ * up component-level properties to the same base tokens.
+ */
+export function buildDtcgDocument(parsed: ClassifiedTokens): DtcgDocument {
+  const color: DtcgGroup = {};
+  for (const [name, hex] of parsed.colors) {
+    color[name] = { $value: hex, $type: 'color' };
+  }
+
+  const spacing: DtcgGroup = {};
+  for (const [name, dim] of parsed.spacing) {
+    spacing[name] = { $value: dim, $type: 'dimension' };
+  }
+
+  const radius: DtcgGroup = {};
+  for (const [name, dim] of Object.entries(ROUNDED_SCALE)) {
+    radius[name] = { $value: dim, $type: 'dimension' };
+  }
+
+  const typography: DtcgGroup = {};
+  for (const [level, props] of Object.entries(TYPOGRAPHY_LEVELS)) {
+    typography[level] = buildTypographyLeaf(props);
+  }
+
+  const component: DtcgGroup = {};
+  for (const [name, entries] of Object.entries(COMPONENTS)) {
+    const group: DtcgGroup = {};
+    for (const [prop, value] of Object.entries(entries)) {
+      group[prop] = {
+        $value: rewriteDesignMdRef(value),
+        $type: inferDtcgType(prop, value),
+      };
+    }
+    component[name] = group;
+  }
+
+  return {
+    $schema: 'https://design-tokens.github.io/community-group/format/',
+    $description:
+      "Murphy's Law Archive design tokens. Generated from web/DESIGN.md " +
+      '(and the upstream web/styles/partials/variables.css) by ' +
+      'web/scripts/export-design-tokens.ts. Do not hand-edit; re-run ' +
+      '`npm --prefix web run design:export` to regenerate.',
+    color,
+    dimension: { spacing, radius },
+    typography,
+    component,
+  };
+}
+
+function buildTypographyLeaf(props: TypographyLevel): DtcgLeafToken {
+  const value: Record<string, string | number> = {
+    fontFamily: props.fontFamily,
+    fontSize: props.fontSize,
+    fontWeight: props.fontWeight,
+    lineHeight: props.lineHeight,
+  };
+  if (props.letterSpacing !== undefined) {
+    value.letterSpacing = props.letterSpacing;
+  }
+  return { $value: value, $type: 'typography' };
+}
+
+/**
+ * Translate DESIGN.md's `{colors.bg}` / `{rounded.md}` / `{typography.body-md}`
+ * references into the DTCG path form this export uses.
+ *
+ * DESIGN.md lives in a flat namespace (colors, rounded, typography, spacing).
+ * DTCG output nests `rounded` under `dimension.radius` and `spacing` under
+ * `dimension.spacing`. We rewrite the prefix; the leaf name is unchanged.
+ */
+export function rewriteDesignMdRef(raw: string): string {
+  const m = raw.match(/^\{([a-z]+)\.([a-z0-9-]+)\}$/i);
+  if (!m) return raw;
+  const category = m[1]!;
+  const leaf = m[2]!;
+  switch (category) {
+    case 'colors':
+      return `{color.${leaf}}`;
+    case 'rounded':
+      return `{dimension.radius.${leaf}}`;
+    case 'spacing':
+      return `{dimension.spacing.${leaf}}`;
+    case 'typography':
+      return `{typography.${leaf}}`;
+    default:
+      return raw;
+  }
+}
+
+/**
+ * Infer the DTCG `$type` for a component-level property. We key off the
+ * property name rather than the value because components reference tokens
+ * by path (`{colors.bg}`), not literals, so the value doesn't carry type
+ * information by itself.
+ */
+export function inferDtcgType(prop: string, value: string): string {
+  if (/color/i.test(prop)) return 'color';
+  if (prop === 'rounded' || prop === 'radius') return 'dimension';
+  if (prop === 'typography') return 'typography';
+  if (prop === 'width' || prop === 'height' || /size|spacing/i.test(prop)) {
+    return 'dimension';
+  }
+  if (value.startsWith('{')) return 'other';
+  return 'other';
+}
+
+export interface ExportRunOptions {
+  variablesCssPath: string;
+  outputPath: string;
+  readFile: (p: string) => string;
+  existsFile: (p: string) => boolean;
+  mkdirp: (p: string) => void;
+  writeFile: (p: string, contents: string) => void;
+  logger: Pick<Console, 'log' | 'error'>;
+}
+
+export function runExport(options: ExportRunOptions): 0 | 1 {
+  if (!options.existsFile(options.variablesCssPath)) {
+    options.logger.error(
+      `design tokens export: ${options.variablesCssPath} not found.`,
+    );
+    return 1;
+  }
+  const css = options.readFile(options.variablesCssPath);
+  const parsed = classifyTokens(parseCssVariables(css));
+  const doc = buildDtcgDocument(parsed);
+  const serialized = JSON.stringify(doc, null, 2) + '\n';
+  options.mkdirp(path.dirname(options.outputPath));
+  options.writeFile(options.outputPath, serialized);
+  options.logger.log(`Wrote ${options.outputPath}`);
+  return 0;
+}
+
+function isMain(): boolean {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return import.meta.url === new URL(`file://${entry}`).href;
+  } catch {
+    return false;
+  }
+}
+
+if (isMain()) {
+  const code = runExport({
+    variablesCssPath: VARIABLES_CSS_PATH,
+    outputPath: DEFAULT_OUTPUT_PATH,
+    readFile: (p) => fs.readFileSync(p, 'utf8'),
+    existsFile: (p) => fs.existsSync(p),
+    mkdirp: (p) => fs.mkdirSync(p, { recursive: true }),
+    writeFile: (p, c) => fs.writeFileSync(p, c, 'utf8'),
+    logger: console,
+  });
+  process.exit(code);
+}

--- a/web/scripts/sync-design-tokens.ts
+++ b/web/scripts/sync-design-tokens.ts
@@ -123,16 +123,15 @@ function remOrPxToPx(raw: string): number | null {
  *
  * Keep this in sync with web/styles/partials/base.css and components.css.
  */
-const TYPOGRAPHY_LEVELS: Record<
-  string,
-  {
-    fontFamily: string;
-    fontSize: string;
-    fontWeight: number;
-    lineHeight: number | string;
-    letterSpacing?: string;
-  }
-> = {
+export interface TypographyLevel {
+  fontFamily: string;
+  fontSize: string;
+  fontWeight: number;
+  lineHeight: number | string;
+  letterSpacing?: string;
+}
+
+export const TYPOGRAPHY_LEVELS: Record<string, TypographyLevel> = {
   display: {
     fontFamily: 'Work Sans, system-ui',
     fontSize: '48px',
@@ -194,7 +193,7 @@ const TYPOGRAPHY_LEVELS: Record<
  * Corner-radius scale. Derived from observed border-radius values in
  * components.css and calculator.css; not currently tokenized in CSS.
  */
-const ROUNDED_SCALE: Record<string, string> = {
+export const ROUNDED_SCALE: Record<string, string> = {
   sm: '4px',
   md: '6px',
   lg: '8px',
@@ -207,7 +206,7 @@ const ROUNDED_SCALE: Record<string, string> = {
  * generated `colors` block via DESIGN.md's `{path.to.token}` syntax.
  * Keep this aligned with web/styles/partials/components.css and theme.css.
  */
-const COMPONENTS: Record<string, Record<string, string>> = {
+export const COMPONENTS: Record<string, Record<string, string>> = {
   'btn-primary': {
     backgroundColor: '{colors.btn-primary-bg}',
     textColor: '{colors.btn-primary-fg}',

--- a/web/tests/export-design-tokens.test.ts
+++ b/web/tests/export-design-tokens.test.ts
@@ -1,0 +1,333 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildDtcgDocument,
+  rewriteDesignMdRef,
+  inferDtcgType,
+  runExport,
+  type DtcgDocument,
+  type DtcgGroup,
+  type DtcgLeafToken,
+  type ExportRunOptions,
+} from '../scripts/export-design-tokens.ts';
+import {
+  classifyTokens,
+  parseCssVariables,
+  type ClassifiedTokens,
+} from '../scripts/sync-design-tokens.ts';
+
+interface BuildLocalThis {
+  parsed?: ClassifiedTokens;
+  doc?: DtcgDocument;
+}
+
+interface RewriteLocalThis {
+  input?: string;
+  rewritten?: string;
+}
+
+interface InferLocalThis {
+  type?: string;
+}
+
+interface RunExportLocalThis {
+  files?: Map<string, string>;
+  dirs?: Set<string>;
+  written?: Map<string, string>;
+  logs?: string[];
+  errors?: string[];
+  options?: ExportRunOptions;
+  code?: 0 | 1;
+}
+
+function sampleCss(): string {
+  return `:root {
+  --space-1: 0.25rem;
+  --space-4: 1rem;
+  --bg: #ffffff;
+  --fg: #111827;
+  --primary: #030213;
+}`;
+}
+
+function buildRunExportLocalThis(
+  initialFiles: Record<string, string> = {},
+): RunExportLocalThis {
+  const localThis: RunExportLocalThis = {};
+  localThis.files = new Map(Object.entries(initialFiles));
+  localThis.dirs = new Set();
+  localThis.written = new Map();
+  localThis.logs = [];
+  localThis.errors = [];
+  localThis.options = {
+    variablesCssPath: '/virt/variables.css',
+    outputPath: '/virt/.design-exports/design-tokens.dtcg.json',
+    readFile: (p: string): string => {
+      const value = localThis.files!.get(p);
+      if (value === undefined) {
+        throw new Error(`readFile missing: ${p}`);
+      }
+      return value;
+    },
+    existsFile: (p: string): boolean => localThis.files!.has(p),
+    mkdirp: (p: string): void => {
+      localThis.dirs!.add(p);
+    },
+    writeFile: (p: string, contents: string): void => {
+      localThis.written!.set(p, contents);
+      localThis.files!.set(p, contents);
+    },
+    logger: {
+      log: (...args: unknown[]): void => {
+        localThis.logs!.push(args.map((a) => String(a)).join(' '));
+      },
+      error: (...args: unknown[]): void => {
+        localThis.errors!.push(args.map((a) => String(a)).join(' '));
+      },
+    },
+  };
+  return localThis;
+}
+
+describe('buildDtcgDocument', () => {
+  it('emits color / dimension / typography / component groups in DTCG shape', () => {
+    const localThis: BuildLocalThis = {};
+    localThis.parsed = classifyTokens(parseCssVariables(sampleCss()));
+    localThis.doc = buildDtcgDocument(localThis.parsed);
+
+    expect(localThis.doc.$schema).toContain('design-tokens');
+    expect(localThis.doc.color).toBeDefined();
+    expect(localThis.doc.dimension).toBeDefined();
+    expect(localThis.doc.typography).toBeDefined();
+    expect(localThis.doc.component).toBeDefined();
+  });
+
+  it('emits each color as a leaf with $value (hex) and $type "color"', () => {
+    const localThis: BuildLocalThis = {};
+    localThis.parsed = classifyTokens(parseCssVariables(sampleCss()));
+    localThis.doc = buildDtcgDocument(localThis.parsed);
+
+    const bg = localThis.doc.color['bg'] as DtcgLeafToken;
+    expect(bg.$value).toBe('#ffffff');
+    expect(bg.$type).toBe('color');
+
+    const primary = localThis.doc.color['primary'] as DtcgLeafToken;
+    expect(primary.$value).toBe('#030213');
+    expect(primary.$type).toBe('color');
+  });
+
+  it('emits spacing and radius under dimension.* as dimension tokens', () => {
+    const localThis: BuildLocalThis = {};
+    localThis.parsed = classifyTokens(parseCssVariables(sampleCss()));
+    localThis.doc = buildDtcgDocument(localThis.parsed);
+
+    const dim = localThis.doc.dimension as DtcgGroup;
+    const spacing = dim['spacing'] as DtcgGroup;
+    const radius = dim['radius'] as DtcgGroup;
+
+    expect((spacing['1'] as DtcgLeafToken).$value).toBe('4px');
+    expect((spacing['1'] as DtcgLeafToken).$type).toBe('dimension');
+    expect((spacing['4'] as DtcgLeafToken).$value).toBe('16px');
+
+    expect((radius['sm'] as DtcgLeafToken).$value).toBe('4px');
+    expect((radius['sm'] as DtcgLeafToken).$type).toBe('dimension');
+    expect((radius['full'] as DtcgLeafToken).$value).toBe('9999px');
+  });
+
+  it('emits typography levels as composite $type "typography" tokens', () => {
+    const localThis: BuildLocalThis = {};
+    localThis.parsed = classifyTokens(parseCssVariables(sampleCss()));
+    localThis.doc = buildDtcgDocument(localThis.parsed);
+
+    const display = localThis.doc.typography['display'] as DtcgLeafToken;
+    expect(display.$type).toBe('typography');
+    const value = display.$value as Record<string, string | number>;
+    expect(value.fontFamily).toBe('Work Sans, system-ui');
+    expect(value.fontSize).toBe('48px');
+    expect(value.fontWeight).toBe(700);
+    expect(value.lineHeight).toBe(1.1);
+    expect(value.letterSpacing).toBe('-0.02em');
+  });
+
+  it('omits letterSpacing when absent from the source typography level', () => {
+    const localThis: BuildLocalThis = {};
+    localThis.parsed = classifyTokens(parseCssVariables(sampleCss()));
+    localThis.doc = buildDtcgDocument(localThis.parsed);
+
+    const h1 = localThis.doc.typography['h1'] as DtcgLeafToken;
+    const value = h1.$value as Record<string, string | number>;
+    expect(value.letterSpacing).toBeUndefined();
+  });
+
+  it('preserves component entries as DTCG references pointing at base tokens', () => {
+    const localThis: BuildLocalThis = {};
+    localThis.parsed = classifyTokens(parseCssVariables(sampleCss()));
+    localThis.doc = buildDtcgDocument(localThis.parsed);
+
+    const btnPrimary = localThis.doc.component['btn-primary'] as DtcgGroup;
+    const bg = btnPrimary['backgroundColor'] as DtcgLeafToken;
+    expect(bg.$value).toBe('{color.btn-primary-bg}');
+    expect(bg.$type).toBe('color');
+
+    const rounded = btnPrimary['rounded'] as DtcgLeafToken;
+    expect(rounded.$value).toBe('{dimension.radius.md}');
+    expect(rounded.$type).toBe('dimension');
+
+    const typography = btnPrimary['typography'] as DtcgLeafToken;
+    expect(typography.$value).toBe('{typography.body-md}');
+    expect(typography.$type).toBe('typography');
+  });
+
+  it('round-trips every entry from the sync script COMPONENTS map', async () => {
+    const localThis: BuildLocalThis = {};
+    localThis.parsed = classifyTokens(parseCssVariables(sampleCss()));
+    localThis.doc = buildDtcgDocument(localThis.parsed);
+
+    const { COMPONENTS } = await import('../scripts/sync-design-tokens.ts');
+    for (const name of Object.keys(COMPONENTS)) {
+      expect(localThis.doc.component[name]).toBeDefined();
+    }
+  });
+});
+
+describe('rewriteDesignMdRef', () => {
+  it('rewrites {colors.*} into DTCG {color.*}', () => {
+    const localThis: RewriteLocalThis = {};
+    localThis.input = '{colors.btn-primary-bg}';
+    localThis.rewritten = rewriteDesignMdRef(localThis.input);
+
+    expect(localThis.rewritten).toBe('{color.btn-primary-bg}');
+  });
+
+  it('nests {rounded.*} under dimension.radius', () => {
+    const localThis: RewriteLocalThis = {};
+    localThis.input = '{rounded.md}';
+    localThis.rewritten = rewriteDesignMdRef(localThis.input);
+
+    expect(localThis.rewritten).toBe('{dimension.radius.md}');
+  });
+
+  it('nests {spacing.*} under dimension.spacing', () => {
+    const localThis: RewriteLocalThis = {};
+    localThis.input = '{spacing.4}';
+    localThis.rewritten = rewriteDesignMdRef(localThis.input);
+
+    expect(localThis.rewritten).toBe('{dimension.spacing.4}');
+  });
+
+  it('leaves {typography.*} untouched (already at the DTCG root path)', () => {
+    const localThis: RewriteLocalThis = {};
+    localThis.input = '{typography.body-md}';
+    localThis.rewritten = rewriteDesignMdRef(localThis.input);
+
+    expect(localThis.rewritten).toBe('{typography.body-md}');
+  });
+
+  it('passes through non-reference values (literal dimensions etc.)', () => {
+    const localThis: RewriteLocalThis = {};
+    localThis.input = '24px';
+    localThis.rewritten = rewriteDesignMdRef(localThis.input);
+
+    expect(localThis.rewritten).toBe('24px');
+  });
+
+  it('passes through references to unknown categories unchanged', () => {
+    const localThis: RewriteLocalThis = {};
+    localThis.input = '{elevation.card}';
+    localThis.rewritten = rewriteDesignMdRef(localThis.input);
+
+    expect(localThis.rewritten).toBe('{elevation.card}');
+  });
+});
+
+describe('inferDtcgType', () => {
+  it('maps any prop with "color" in the name to $type "color"', () => {
+    const localThis: InferLocalThis = {};
+    localThis.type = inferDtcgType('backgroundColor', '{colors.bg}');
+    expect(localThis.type).toBe('color');
+
+    expect(inferDtcgType('textColor', '{colors.fg}')).toBe('color');
+    expect(inferDtcgType('borderColor', '#000')).toBe('color');
+  });
+
+  it('maps "rounded" / "radius" to $type "dimension"', () => {
+    expect(inferDtcgType('rounded', '{rounded.md}')).toBe('dimension');
+    expect(inferDtcgType('radius', '{rounded.md}')).toBe('dimension');
+  });
+
+  it('maps "typography" to $type "typography"', () => {
+    expect(inferDtcgType('typography', '{typography.body-md}')).toBe(
+      'typography',
+    );
+  });
+
+  it('maps literal pixel widths and heights to $type "dimension"', () => {
+    expect(inferDtcgType('width', '24px')).toBe('dimension');
+    expect(inferDtcgType('height', '44px')).toBe('dimension');
+    expect(inferDtcgType('fontSize', '16px')).toBe('dimension');
+  });
+
+  it('falls back to "other" for unknown props', () => {
+    const localThis: InferLocalThis = {};
+    localThis.type = inferDtcgType('mysteryProp', '{colors.bg}');
+    expect(localThis.type).toBe('other');
+
+    expect(inferDtcgType('anotherProp', 'literal-string')).toBe('other');
+  });
+});
+
+describe('runExport', () => {
+  it('writes a JSON file at the configured output path', () => {
+    const localThis = buildRunExportLocalThis({
+      '/virt/variables.css': sampleCss(),
+    });
+
+    localThis.code = runExport(localThis.options!);
+
+    expect(localThis.code).toBe(0);
+    expect(
+      localThis.written!.has('/virt/.design-exports/design-tokens.dtcg.json'),
+    ).toBe(true);
+    const written = localThis.written!.get(
+      '/virt/.design-exports/design-tokens.dtcg.json',
+    )!;
+    const parsed = JSON.parse(written) as DtcgDocument;
+    expect(parsed.$schema).toContain('design-tokens');
+    expect((parsed.color['bg'] as DtcgLeafToken).$value).toBe('#ffffff');
+  });
+
+  it('ensures the parent directory exists before writing', () => {
+    const localThis = buildRunExportLocalThis({
+      '/virt/variables.css': sampleCss(),
+    });
+
+    runExport(localThis.options!);
+
+    expect(localThis.dirs!.has('/virt/.design-exports')).toBe(true);
+  });
+
+  it('logs a user-visible "Wrote <path>" success line', () => {
+    const localThis = buildRunExportLocalThis({
+      '/virt/variables.css': sampleCss(),
+    });
+
+    runExport(localThis.options!);
+
+    expect(
+      localThis.logs!.some((l) => l.includes('Wrote /virt/.design-exports/')),
+    ).toBe(true);
+  });
+
+  it('returns 1 with a helpful error when variables.css is missing', () => {
+    const localThis = buildRunExportLocalThis({});
+
+    localThis.code = runExport(localThis.options!);
+
+    expect(localThis.code).toBe(1);
+    expect(
+      localThis.errors!.some((e) =>
+        e.includes('/virt/variables.css not found'),
+      ),
+    ).toBe(true);
+    expect(localThis.written!.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- New script `web/scripts/export-design-tokens.ts` wired up as `npm --prefix web run design:export`. Emits the DESIGN.md token catalogue as a [Design Tokens Community Group](https://tr.designtokens.org/format/) JSON document at `web/.design-exports/design-tokens.dtcg.json`.
- Shape: `color.*`, `dimension.spacing.*`, `dimension.radius.*`, `typography.*` (composite), `component.*` (references into base tokens). DESIGN.md's `{colors.foo}` / `{rounded.md}` refs are rewritten into the nested DTCG paths (`{color.foo}` / `{dimension.radius.md}`).
- Reuses `parseCssVariables` + `classifyTokens` from `sync-design-tokens.ts` so the export cannot drift from what `design:check` publishes. `TYPOGRAPHY_LEVELS`, `ROUNDED_SCALE`, and `COMPONENTS` are now exported from that module for this purpose.
- Output dir `web/.design-exports/` is gitignored. The export is intentionally NOT in `ci:web`; `design:check` remains the server-side gate. This is a designer-facing on-demand artifact.
- 22 new vitest cases cover `buildDtcgDocument`, `rewriteDesignMdRef`, `inferDtcgType`, and the `runExport` IO shell (using the existing localThis pattern).
- Implements Item 6 (token export) of the design-md follow-ups plan.

## Why DTCG and not Tailwind

- DTCG is framework-agnostic and is what Figma Variables / Tokens Studio / Style Dictionary consume natively.
- Tailwind is only useful when someone is also building a Tailwind config elsewhere; nothing in this monorepo does. Easy to add later as a sibling script if needed.

## Test plan

- [x] `npm --prefix web run design:export` writes `web/.design-exports/design-tokens.dtcg.json` with the expected shape.
- [x] `npm run ci:web` -> 92 test files / 2663 tests pass; typecheck, ESLint, Stylelint, html-validate, design:check, build all green. (`scripts/**` is excluded from coverage, no threshold concerns.)
- [ ] GitHub Actions CI green on the branch before marking ready.
- [ ] Spot-check the generated JSON in Figma Tokens Studio / VS Code JSON schema (manual verification by a designer).

## Stacking

This PR targets `main` independently of #88 (Item 4 components expansion). Merge order doesn't matter; whichever lands second will rebase cleanly (no file overlap with #88 beyond the `COMPONENTS` constant in `web/scripts/sync-design-tokens.ts`, which #88 edits and this PR only adds an `export` modifier to).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ravidorr/murphys-laws/89)
<!-- Reviewable:end -->
