### PR TITLE
chore: extend ship-skill version-bump scope to shared/content

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -37,11 +37,11 @@ Bump the root `package.json` on every ship. Bump a sub-package's version file **
 | File | Field(s) | Scheme | Example | When to bump |
 |------|----------|--------|---------|--------------|
 | `package.json` (root) | `version` | `MAJOR.MINOR.PATCH` | `2.1.1` → `2.1.2` | Always. Drives the Sentry `release` tag across the repo. |
-| `web/package.json` | `version` | `MAJOR.MINOR.PATCH` | `3.1.35` → `3.1.36` | Only when user-facing web code changed. Version is embedded in built web assets and Sentry web releases. **Build-time tooling under `web/scripts/` that emits artifacts for OTHER platforms (e.g. `export-ios-tokens.ts`, `export-android-tokens.ts`) is NOT a web change for versioning purposes** - bumping web for it creates phantom Sentry web releases. |
+| `web/package.json` | `version` | `MAJOR.MINOR.PATCH` | `3.1.35` → `3.1.36` | Only when files that ship in the web bundle changed: `web/**` user-facing code, OR any `shared/` path the web SSG bakes in (today: `shared/content/**`, see [web/scripts/ssg.ts](web/scripts/ssg.ts) constant `SHARED_CONTENT_DIR`). Version is embedded in built web assets and Sentry web releases. **Build-time tooling under `web/scripts/` that emits artifacts for OTHER platforms (e.g. `export-ios-tokens.ts`, `export-android-tokens.ts`) is NOT a web change for versioning purposes** - bumping web for it creates phantom Sentry web releases. |
 | `backend/package.json` | `version` | `MAJOR.MINOR.PATCH` | `2.0.14` → `2.0.15` | Only when files under `backend/` changed. |
 | `mcp/package.json` | `version` | `MAJOR.MINOR.PATCH` | - | Only when files under `mcp/` changed. |
-| `ios/project.yml` AND `ios/MurphysLaws/Info.plist` | `MARKETING_VERSION` / `CFBundleShortVersionString` (semver) AND `CURRENT_PROJECT_VERSION` / `CFBundleVersion` (monotonic build number) | semver + integer | `1.0.1` → `1.0.2`, build `2` → `3` | Only when files under `ios/` changed. Surfaces in TestFlight, App Store, Sentry iOS dashboards. Keep the same value in `project.yml` and `Info.plist` so XcodeGen regeneration is a no-op. |
-| `android/app/build.gradle.kts` | `versionName` (semver) AND `versionCode` (monotonic int) | semver + integer | `versionName "1.0.1"`, `versionCode 2` → `versionName "1.0.2"`, `versionCode 3` | Only when files under `android/` changed. Surfaces in Play Console and Sentry Android dashboards. |
+| `ios/project.yml` AND `ios/MurphysLaws/Info.plist` | `MARKETING_VERSION` / `CFBundleShortVersionString` (semver) AND `CURRENT_PROJECT_VERSION` / `CFBundleVersion` (monotonic build number) | semver + integer | `1.0.1` → `1.0.2`, build `2` → `3` | Only when files that ship in the iOS app binary changed: `ios/**`, OR any `shared/` path bundled into the app (today: `shared/content/**`, declared in [ios/project.yml](ios/project.yml) `sources:`). Surfaces in TestFlight, App Store, Sentry iOS dashboards. Keep the same value in `project.yml` and `Info.plist` so XcodeGen regeneration is a no-op. |
+| `android/app/build.gradle.kts` | `versionName` (semver) AND `versionCode` (monotonic int) | semver + integer | `versionName "1.0.1"`, `versionCode 2` → `versionName "1.0.2"`, `versionCode 3` | Only when files that ship in the Android app binary changed: `android/**`, OR any `shared/` path copied into app assets (today: `shared/content/**`, declared in the `copySharedContent` task in [android/app/build.gradle.kts](android/app/build.gradle.kts)). Surfaces in Play Console and Sentry Android dashboards. |
 
 Increment only the **PATCH** segment of each unless the change warrants MINOR (new user-facing feature, e.g. bundling a new font, adding a screen, opt-in API) or MAJOR (breaking change). When you bump MINOR or MAJOR on any version file, **alert the user explicitly per the version-bump rule** and confirm before proceeding.
 
@@ -49,19 +49,23 @@ Increment only the **PATCH** segment of each unless the change warrants MINOR (n
 
 ### How to decide what changed
 
-Before bumping, inspect the staged diff per platform:
+Before bumping, inspect the staged diff per platform. **Note that `shared/content/` ships in all three platform binaries (web SSG, iOS resource bundle, Android assets), so it must be probed alongside each platform's own directory:**
 
 ```bash
-git diff --cached --stat -- web/
+git diff --cached --stat -- web/ shared/content/
 git diff --cached --stat -- backend/
 git diff --cached --stat -- mcp/
-git diff --cached --stat -- ios/
-git diff --cached --stat -- android/
+git diff --cached --stat -- ios/ shared/content/
+git diff --cached --stat -- android/ shared/content/
 ```
 
 If a directory shows no output, do **not** bump that platform's version. `package-lock.json` updates driven purely by the root version bump do not count as a sub-package change.
 
-For `web/`, the diff alone isn't enough: also check whether the changed files are user-facing (`web/src/**`, `web/styles/**`, `web/index.html`) versus build-time tooling (`web/scripts/**` that emits to other platforms). Tooling-only diffs do not warrant a `web/package.json` bump.
+A PR that touches **only** `shared/content/` (e.g. a copy fix on `about.md`) is a real release on every platform that bundles it: web users see a new build, iOS / Android users get an update via TestFlight / Play. The version files must reflect that. Skipping the bump on iOS / Android specifically can block the next upload because App Store Connect / Play Console reject duplicate `CFBundleVersion` / `versionCode`.
+
+For `web/`, the diff alone isn't enough: also check whether the changed files are user-facing (`web/src/**`, `web/styles/**`, `web/index.html`, `shared/content/**`) versus build-time tooling (`web/scripts/**` that emits to other platforms). Tooling-only diffs do not warrant a `web/package.json` bump.
+
+If `ios/project.yml` `sources:` or `android/app/build.gradle.kts` `copySharedContent` (or the equivalent build glue) ever expands to consume more `shared/` paths, update this skill so the probes match the new reality.
 
 ### iOS specifics
 
@@ -193,14 +197,16 @@ Return the PR URL to the user.
 ## Quick-reference checklist
 
 ```
-[ ] Read the diff - understand what changed AND which platform(s) actually changed
+[ ] Read the diff - understand what changed AND which platform binaries it lands in
 [ ] Bump root package.json (always)
-[ ] If user-facing web/ code changed: bump web/package.json
+[ ] If user-facing web/ code OR shared/content/ changed: bump web/package.json
 [ ] If backend/ code changed: bump backend/package.json
 [ ] If mcp/ code changed: bump mcp/package.json
-[ ] If ios/ code changed: bump MARKETING_VERSION+CURRENT_PROJECT_VERSION in ios/project.yml
-    AND CFBundleShortVersionString+CFBundleVersion in ios/MurphysLaws/Info.plist (lockstep)
-[ ] If android/ code changed: bump versionName + versionCode in android/app/build.gradle.kts
+[ ] If ios/ code OR shared/content/ changed: bump MARKETING_VERSION+CURRENT_PROJECT_VERSION
+    in ios/project.yml AND CFBundleShortVersionString+CFBundleVersion in
+    ios/MurphysLaws/Info.plist (lockstep)
+[ ] If android/ code OR shared/content/ changed: bump versionName + versionCode in
+    android/app/build.gradle.kts
 [ ] Add CHANGELOG bullet under [Unreleased]
 [ ] git fetch origin main && git rebase origin/main
 [ ] git add <files>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- `ship` skill ([.claude/skills/ship/SKILL.md](.claude/skills/ship/SKILL.md)) version-bump scope expanded to cover `shared/content/**`. Both mobile apps bundle that directory (`ios/project.yml` `sources:` mounts `../shared/content` as a resource folder; `android/app/build.gradle.kts` copies it into app assets via the `copySharedContent` preBuild task) and the web SSG bakes it into the static build (`web/scripts/ssg.ts` `SHARED_CONTENT_DIR`). Without including it in the iOS / Android / web rule, a PR that only edits `shared/content/about.md` (a copy fix) would change user-visible content in all three platforms while keeping `CFBundleVersion` / `versionCode` / `web/package.json` static, blocking the next App Store / Play Console upload as a duplicate build. Updates the rule rows, the "How to decide what changed" probes, and the quick-reference checklist. Credit: flagged by Codex P1 review on [#98](https://github.com/ravidorr/murphys-laws/pull/98).
+
+### Changed
 - `ship` skill ([.claude/skills/ship/SKILL.md](.claude/skills/ship/SKILL.md)) now documents iOS (`MARKETING_VERSION` + `CURRENT_PROJECT_VERSION` in `ios/project.yml`, `CFBundleShortVersionString` + `CFBundleVersion` in `Info.plist`) and Android (`versionName` + `versionCode` in `app/build.gradle.kts`) version-file rules alongside the existing web / backend / mcp guidance. Also clarifies that build-time tooling under `web/scripts/` that emits artifacts for OTHER platforms (e.g. `export-ios-tokens.ts`, `export-android-tokens.ts`) is NOT a web change for versioning purposes - bumping `web/package.json` for a tooling-only diff creates phantom Sentry web releases. Closes the gap that produced incorrect web bumps and missing iOS/Android bumps in the design-tokens-mobile rollout PRs (#92-#97).
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.4.15",
+  "version": "2.4.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murphys-laws-monorepo",
-      "version": "2.4.15",
+      "version": "2.4.16",
       "license": "CC0-1.0",
       "workspaces": [
         "backend",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.4.15",
+  "version": "2.4.16",
   "description": "Murphy's Laws - Monorepo for Web, iOS, and Android apps",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Summary

Closes the P1 Codex comment on #98 about mobile version-bump scope being too narrow.

## The bug

The skill landed in #98 stated:

> Only when files under `ios/` changed.
> Only when files under `android/` changed.

But both mobile apps bundle `shared/content/` at build time:

- **iOS**: [ios/project.yml](ios/project.yml) `sources:` block:
  ```yaml
  - path: ../shared/content
    name: content
    type: folder
    buildPhase: resources
  ```
- **Android**: [android/app/build.gradle.kts](android/app/build.gradle.kts) `copySharedContent` task wired into `preBuild`:
  ```kotlin
  tasks.register<Copy>("copySharedContent") {
      from("${project.rootDir}/../shared/content") {
          include("*.md", "*.json")
      }
      into("${project.projectDir}/src/main/assets/content")
  }
  ```

And web's SSG also reads it (`web/scripts/ssg.ts` `SHARED_CONTENT_DIR`).

Result: a PR that only edits `shared/content/about.md` (a copy fix) would change the about screen in all three platforms while leaving `CFBundleVersion` / `versionCode` / `web/package.json` untouched. App Store Connect and Play Console reject duplicate build numbers, so the next mobile upload would be blocked.

## The fix

[.claude/skills/ship/SKILL.md](.claude/skills/ship/SKILL.md):

- Each platform row in the version-bump table now reads "Only when files that ship in the `<platform>` binary changed: `<platform>/**`, OR any `shared/` path bundled into the binary (today: `shared/content/**`, declared in [build config])." Web row gets the same treatment for SSG-baked content.
- "How to decide what changed" probes now include `shared/content/`:
  ```bash
  git diff --cached --stat -- web/ shared/content/
  git diff --cached --stat -- ios/ shared/content/
  git diff --cached --stat -- android/ shared/content/
  ```
- Quick-reference checklist updated: each platform bullet now reads "If `<platform>/` code OR `shared/content/` changed".
- Forward-looking note: if the build configs ever bundle additional `shared/` paths, this skill must be updated to match.

## Why this is P1

Without the fix, the most innocuous-looking PR (a typo fix in `shared/content/`) silently breaks the mobile upload pipeline. The fix is a docs-only change but the policy gap is real.

## Test plan

- [ ] Read the diff and confirm the new rule rows match the actual `ios/project.yml` and `android/app/build.gradle.kts` references.
- [ ] Confirm the checklist captures the new platform decisions.
- [ ] No code changes -- skill text only -- so no CI is exercising this. CI on the branch should be a no-op pass.
- [ ] Open chain (#92-#97) is unaffected by the rule expansion: none of those PRs touch `shared/content/`. They will rebase off main once this lands (CHANGELOG / version conflicts only, no logic changes).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ravidorr/murphys-laws/99)
<!-- Reviewable:end -->
