### PR TITLE
chore: limit Web CI push runs to main

### DIFF
--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -2,6 +2,8 @@ name: Web CI
 
 on:
   push:
+    branches:
+      - main
     paths:
       - 'web/**'
       - 'shared/modules/**'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Web CI now runs on pull requests and `main` pushes only, avoiding duplicate `test-and-build` and `e2e-tests` jobs when a feature branch with an open PR is updated. Root bumped to `2.4.20`.
 - iOS CI now runs on pull requests and `main` pushes only, avoiding duplicate macOS jobs when a feature branch with an open PR is updated. Root bumped to `2.4.18`.
 - iOS skeleton-loading shimmer now consumes `DS.Color.mutedFg` (light + dark from the Asset Catalog) instead of hand-branching on `@Environment(\.colorScheme)` with hardcoded `Color(white:)` greys. [ios/MurphysLaws/Views/Home/SkeletonViews.swift](ios/MurphysLaws/Views/Home/SkeletonViews.swift). The dark-mode swap is now driven by the system trait collection via `Assets.xcassets/DS/muted-fg.colorset`, matching how every other DS color works. PR iOS-2 of the design-tokens-mobile rollout; calculator and vote-thumb surfaces are explicitly out of scope (HIG-idiomatic semantic colors `.green` / `.orange` / `.red` are correct on iOS), and no rank-style surface exists on iOS to migrate yet. iOS app bumped to `1.0.2` / build `3`; root to `2.4.17`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.4.19",
+  "version": "2.4.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murphys-laws-monorepo",
-      "version": "2.4.19",
+      "version": "2.4.20",
       "license": "CC0-1.0",
       "workspaces": [
         "backend",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.4.19",
+  "version": "2.4.20",
   "description": "Murphy's Laws - Monorepo for Web, iOS, and Android apps",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Summary

- Limits the Web CI `push` trigger to `main` so PR branch updates do not run duplicate jobs.
- Keeps `pull_request` validation for web-related PR changes.
- Bumps the root release version to `2.4.20` and records the workflow change in the changelog.

## Test plan

- [x] Commit hooks passed backend/web typecheck, lint, coverage, and E2E.
- [x] Verified `.github/workflows/web-ci.yml` has no IDE diagnostics.
- [ ] Confirm a future web-related PR branch push only creates the `pull_request` Web CI checks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ravidorr/murphys-laws/101)
<!-- Reviewable:end -->
