### PR TITLE
docs: correct server-maintenance runbook to match live state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - iOS skeleton-loading shimmer now consumes `DS.Color.mutedFg` (light + dark from the Asset Catalog) instead of hand-branching on `@Environment(\.colorScheme)` with hardcoded `Color(white:)` greys. [ios/MurphysLaws/Views/Home/SkeletonViews.swift](ios/MurphysLaws/Views/Home/SkeletonViews.swift). The dark-mode swap is now driven by the system trait collection via `Assets.xcassets/DS/muted-fg.colorset`, matching how every other DS color works. PR iOS-2 of the design-tokens-mobile rollout; calculator and vote-thumb surfaces are explicitly out of scope (HIG-idiomatic semantic colors `.green` / `.orange` / `.red` are correct on iOS), and no rank-style surface exists on iOS to migrate yet. iOS app bumped to `1.0.2` / build `3`; root to `2.4.17`.
 
 ### Fixed
+- `shared/docs/SERVER_MAINTENANCE.md` corrected to match the live `murphys-main` server: the
+  `sudo -i pm2 list` recipe (which fails because pm2 lives in root's nvm and is not on sudo's
+  PATH) is replaced with a working `sudo bash -c "exec $(...)"` invocation that resolves the
+  binary via glob and survives node version upgrades; the pre-update DB-backup step now calls
+  the actual script `/usr/local/bin/backup-murphys.sh` (the doc had a non-existent `-db`
+  variant) and references the real DB path `/root/murphys-laws/backend/murphys.db` instead of
+  a guessed `/var/lib/...`; OS string bumped to Ubuntu 24.04.4 LTS; "Automated Security
+  Updates" section reframed from "install and enable" to "audit existing config" since
+  `unattended-upgrades` 2.9.1 is already installed and configured (which is why kernel
+  packages auto-install but `Reboot Required` periodically lights up). Root bumped to `2.4.28`.
 - Nested iOS project configuration now points `INFOPLIST_FILE` at the app plist
   path that exists relative to that project root.
 - iOS test plan wiring now lives in `project.yml`, so XcodeGen regeneration in CI

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.4.27",
+  "version": "2.4.28",
   "description": "Murphy's Laws - Monorepo for Web, iOS, and Android apps",
   "private": true,
   "workspaces": [

--- a/shared/docs/SERVER_MAINTENANCE.md
+++ b/shared/docs/SERVER_MAINTENANCE.md
@@ -6,9 +6,12 @@
 - **Host Alias:** `murphys-main` or `murphys`
 - **Hostname:** murphys-laws.com
 - **IP:** Resolved via DNS
-- **OS:** Ubuntu 24.04.3 LTS
-- **Services:** Nginx, PM2, Node.js API server
-- **User:** ravidor
+- **OS:** Ubuntu 24.04.4 LTS
+- **Services:** Nginx, PM2 (systemd unit `pm2-root.service`, runs as root), Node.js API server (tsx)
+- **User:** ravidor (sudo, passwordless)
+- **API process:** `tsx ./src/server/api-server.ts` listening on `127.0.0.1:8787`, proxied by nginx on 443
+- **Live DB path:** `/root/murphys-laws/backend/murphys.db`
+- **DB backups:** `/root/backups/murphys_db_YYYYMMDD_HHMMSS.db` (daily 04:00 cron via `/usr/local/bin/backup-murphys.sh`)
 
 ### 2. n8n Automation Server
 - **Host Alias:** `murphys-n8n`
@@ -61,15 +64,14 @@ The status-report email's "17 pending updates" figure alone is **not** a signal:
 ### 2. Run Updates
 
 ```bash
-# Take a fresh database snapshot before patching
-ssh murphys-main 'sudo /usr/local/bin/backup-murphys-db.sh' \
-  || ssh murphys-main 'cp /var/lib/murphys/murphys.db /var/backups/murphys/murphys_$(date +%Y%m%d_%H%M%S)_pre-patch.db'
+# Take a fresh database snapshot before patching.
+# (Skip this step if you are patching shortly after the daily 04:00 cron has run;
+# the latest /root/backups/murphys_db_*.db file will already be current.)
+ssh murphys-main 'sudo /usr/local/bin/backup-murphys.sh && ls -lht /root/backups/ | head -n 3'
 
 # Update package lists and upgrade all packages
 ssh murphys-main 'sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get upgrade -y'
 ```
-
-> The first line tries the project's existing backup script if present; otherwise falls back to a manual copy. Confirm the actual path/script name on the server and replace as needed before running.
 
 ### 3. Reboot (if required)
 
@@ -96,10 +98,15 @@ ssh murphys-main 'systemctl status nginx --no-pager -l | head -n 10'
 # Check Node.js processes
 ssh murphys-main 'ps aux | grep -E "node|pm2" | grep -v grep'
 
-# Check pm2 (runs as root via pm2-root.service; plain `sudo pm2` fails because pm2
-# lives under /root/.nvm and sudo does not load root's login shell)
+# Check pm2. The daemon runs as root via pm2-root.service; the binary lives under
+# root's nvm install (/root/.nvm/versions/node/<ver>/bin/pm2) and is not on the
+# PATH that `sudo`, `sudo -i`, `sudo bash -lc`, or `sudo su - root -c` resolve in
+# a non-interactive ssh session. Two things actually work:
+#   1. systemctl (canonical liveness check)
+#   2. invoking pm2 via a glob inside `sudo bash -c` so the shell expands the path
+#      as root (survives node version upgrades under nvm)
 ssh murphys-main 'systemctl status pm2-root.service --no-pager -l | head -n 12'
-ssh murphys-main 'sudo -i pm2 list'
+ssh murphys-main 'sudo bash -c "exec \$(ls -1 /root/.nvm/versions/node/*/bin/pm2 | tail -n 1) list"'
 
 # Confirm the API is listening on its loopback port
 ssh murphys-main 'ss -tln | grep ":8787"'
@@ -177,69 +184,68 @@ The n8n service is configured via Docker Compose:
 
 ## Automated Security Updates (unattended-upgrades)
 
-To stop the daily status email's "pending updates" count from being a manual decision, configure `unattended-upgrades` on the main server to apply **security updates only**, automatically. Kernel-triggered reboots stay manual.
+The main server already runs `unattended-upgrades` (verified 2026-04-26 on package version `2.9.1+nmu4ubuntu1`). Security-pocket updates are auto-applied; auto-reboot is intentionally **off**, so kernel packages land but only take effect on the next manual reboot. That is why the daily status email periodically shows `Reboot Required: YES` with a `linux-image-*` entry in `/var/run/reboot-required.pkgs`: that is normal operation, not a misconfiguration.
 
-### 1. Install and enable
+### What's already configured
 
-```bash
-ssh murphys-main 'sudo apt-get install -y unattended-upgrades apt-listchanges'
-ssh murphys-main 'sudo dpkg-reconfigure -f noninteractive unattended-upgrades'
-```
-
-### 2. Configure the policy
-
-Write `/etc/apt/apt.conf.d/52unattended-upgrades-local` (a higher-numbered file overrides the package default, so we never edit `50unattended-upgrades` directly):
-
-```text
-// Apply only security pockets. Explicitly leave -updates, -proposed, and -backports off.
-Unattended-Upgrade::Allowed-Origins {
-    "${distro_id}:${distro_codename}-security";
-    "${distro_id}ESMApps:${distro_codename}-apps-security";
-    "${distro_id}ESM:${distro_codename}-infra-security";
-};
-
-// Never auto-reboot; the daily report surfaces reboot-required and we patch + reboot deliberately.
-Unattended-Upgrade::Automatic-Reboot "false";
-
-// Clean up old kernels/packages so /boot doesn't fill up.
-Unattended-Upgrade::Remove-Unused-Kernel-Packages "true";
-Unattended-Upgrade::Remove-Unused-Dependencies "true";
-
-// If a package upgrade fails, retry once on the next run rather than blocking forever.
-Unattended-Upgrade::MinimalSteps "true";
-
-// Mail the operator on failure only (set this to a real address or leave unset to use logs).
-// Unattended-Upgrade::Mail "ops@murphys-laws.com";
-// Unattended-Upgrade::MailReport "on-change";
-```
-
-And `/etc/apt/apt.conf.d/20auto-upgrades` (this is what the timer reads):
+`/etc/apt/apt.conf.d/20auto-upgrades` (timer settings):
 
 ```text
 APT::Periodic::Update-Package-Lists "1";
-APT::Periodic::Unattended-Upgrade "1";
+APT::Periodic::Download-Upgradeable-Packages "1";
 APT::Periodic::AutocleanInterval "7";
+APT::Periodic::Unattended-Upgrade "1";
 ```
 
-### 3. Verify it runs
+`/etc/apt/apt.conf.d/50unattended-upgrades` (package-default policy) confirmed to include:
+
+- `Unattended-Upgrade::Automatic-Reboot "false"`
+- `Unattended-Upgrade::Automatic-Reboot-WithUsers "false"`
+- `Unattended-Upgrade::Remove-Unused-Kernel-Packages "true"`
+- `Unattended-Upgrade::Remove-Unused-Dependencies "true"`
+
+### Audit the policy
 
 ```bash
-# Dry-run: show what unattended-upgrades would install on the next pass
+# View active config (the package-default file plus any local overrides)
+ssh murphys-main 'sudo cat /etc/apt/apt.conf.d/20auto-upgrades'
+ssh murphys-main 'sudo grep -nE "Allowed-Origins|Automatic-Reboot|Remove-Unused|MinimalSteps" /etc/apt/apt.conf.d/50unattended-upgrades /etc/apt/apt.conf.d/52*-local 2>/dev/null'
+
+# Dry-run the next pass: shows exactly what would install
 ssh murphys-main 'sudo unattended-upgrade --dry-run --debug 2>&1 | tail -n 40'
 
-# Confirm the systemd timer is active
+# Confirm the daily timer is active
 ssh murphys-main 'systemctl list-timers apt-daily-upgrade.timer --no-pager'
 
 # Inspect the most recent run
 ssh murphys-main 'sudo tail -n 50 /var/log/unattended-upgrades/unattended-upgrades.log'
 ```
 
-### What this changes about the daily status email
+### Optional: project-owned override
 
-After this is in place, the report's "Pending Updates: N" line is mostly **non-security** updates (e.g. `-updates` pocket). The signals that still demand action are unchanged:
+If you want the policy pinned in a file you control instead of relying on the package-default `50unattended-upgrades`, drop a higher-numbered override at `/etc/apt/apt.conf.d/52unattended-upgrades-local`. Higher numbers win, so the package default is left untouched. Only add settings you want to change from current behavior, e.g.:
 
-- `Reboot Required: YES` with a kernel package in `reboot-required.pkgs` → schedule a reboot.
-- A non-zero security count that has stayed > 0 for multiple days → unattended-upgrades is failing; check the log above.
+```text
+// Restrict to security pockets explicitly (tighter than the package default).
+Unattended-Upgrade::Allowed-Origins {
+    "${distro_id}:${distro_codename}-security";
+    "${distro_id}ESMApps:${distro_codename}-apps-security";
+    "${distro_id}ESM:${distro_codename}-infra-security";
+};
+
+// If a package upgrade fails, retry on the next run rather than blocking.
+Unattended-Upgrade::MinimalSteps "true";
+
+// Optional: mail on failure (requires Postfix relay configured).
+// Unattended-Upgrade::Mail "ops@murphys-laws.com";
+// Unattended-Upgrade::MailReport "on-change";
+```
+
+### Reading the daily status email under this policy
+
+- `Pending Updates: N` is mostly **non-security** packages (e.g. `-updates` pocket). Routine, not urgent.
+- `Reboot Required: YES` with `linux-image-*` in `reboot-required.pkgs` means a security-tracked kernel was auto-installed and is waiting for a manual reboot to take effect. Schedule one.
+- A security-update count (`apt list --upgradable | grep -Ei "security|esm"`) that stays `> 0` for multiple days means unattended-upgrades is failing. Check the log above.
 
 ## Quick Reference Commands
 


### PR DESCRIPTION
## Summary

Audited `shared/docs/SERVER_MAINTENANCE.md` against the live `murphys-main` server and fixed four real drifts:

- **Broken pm2 verify recipe.** The doc told you to run `sudo -i pm2 list`, but pm2 lives in root's nvm and that command fails with `pm2: command not found`. Replaced with `sudo bash -c "exec $(ls -1 /root/.nvm/versions/node/*/bin/pm2 | tail -n 1) list"`, which expands the glob as root and survives node version upgrades. `systemctl status pm2-root.service` is now also called out as the canonical liveness check.
- **Wrong pre-update DB backup paths.** Doc referenced `/usr/local/bin/backup-murphys-db.sh` (the real script is `backup-murphys.sh`, no `-db`) and a guessed live DB at `/var/lib/murphys/murphys.db` (actual: `/root/murphys-laws/backend/murphys.db`). Backups land in `/root/backups/`. All corrected.
- **OS string out of date.** Bumped from `Ubuntu 24.04.3 LTS` to `Ubuntu 24.04.4 LTS`.
- **"Automated Security Updates" section was misleading.** It was framed as "install + enable" but `unattended-upgrades 2.9.1` is already installed and the existing `/etc/apt/apt.conf.d/{20auto-upgrades,50unattended-upgrades}` already disables auto-reboot, removes unused kernels, etc. Reframed as "what's already configured / how to audit it"; the override file pattern is now flagged as optional, not required. This also explains why the daily status email periodically shows `Reboot Required: YES` with `linux-image-*` pending: that's the existing policy auto-applying kernel security updates and waiting for a manual reboot, exactly as designed.

Server inventory entry for `murphys-main` was also expanded with verified facts (pm2 service unit, API process command and port, live DB path, backup script path and cadence).

Bumped root to `2.4.28`. No sub-package version bumps (docs-only change in `shared/docs/`).

## Test plan

- [ ] Skim the rendered diff on GitHub to confirm the doc still reads cleanly end-to-end.
- [ ] Optional: re-run the `Audit the policy` block from the new section against `murphys-main` and confirm the dry-run / timer / log commands work as documented.
- [ ] Optional: re-run the corrected verify block from § 4 (pm2 glob invocation, API health curl) and confirm output matches what the doc claims.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ravidorr/murphys-laws/107)
<!-- Reviewable:end -->
