### PR TITLE
fix: enforce package version bumps during ship

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -39,7 +39,9 @@ Bump the root `package.json` on every ship. Bump a sub-package's version file **
 | `package.json` (root) | `version` | `MAJOR.MINOR.PATCH` | `2.1.1` → `2.1.2` | Always. Drives the Sentry `release` tag across the repo. |
 | `web/package.json` | `version` | `MAJOR.MINOR.PATCH` | `3.1.35` → `3.1.36` | Only when files that ship in the web bundle changed: `web/**` user-facing code, OR any `shared/` path the web SSG bakes in (today: `shared/content/**`, see [web/scripts/ssg.ts](web/scripts/ssg.ts) constant `SHARED_CONTENT_DIR`). Version is embedded in built web assets and Sentry web releases. **Design-token tooling under `shared/design-tokens/` that emits artifacts for OTHER platforms is NOT a web change for versioning purposes** - bumping web for it creates phantom Sentry web releases. |
 | `backend/package.json` | `version` | `MAJOR.MINOR.PATCH` | `2.0.14` → `2.0.15` | Only when files under `backend/` changed. |
-| `mcp/package.json` | `version` | `MAJOR.MINOR.PATCH` | - | Only when files under `mcp/` changed. |
+| `cli/package.json` | `version` | `MAJOR.MINOR.PATCH` | `0.1.0` → `0.1.1` | Only when files under `cli/` changed. |
+| `mcp/package.json` | `version` | `MAJOR.MINOR.PATCH` | `1.2.1` → `1.2.2` | Only when files under `mcp/` changed. |
+| `sdk/package.json` | `version` | `MAJOR.MINOR.PATCH` | `0.1.0` → `0.1.1` | Only when files under `sdk/` changed. |
 | `ios/project.yml` AND `ios/MurphysLaws/Info.plist` | `MARKETING_VERSION` / `CFBundleShortVersionString` (semver) AND `CURRENT_PROJECT_VERSION` / `CFBundleVersion` (monotonic build number) | semver + integer | `1.0.1` → `1.0.2`, build `2` → `3` | Only when files that ship in the iOS app binary changed: `ios/**`, OR any `shared/` path bundled into the app (today: `shared/content/**`, declared in [ios/project.yml](ios/project.yml) `sources:`). Surfaces in TestFlight, App Store, Sentry iOS dashboards. Keep the same value in `project.yml` and `Info.plist` so XcodeGen regeneration is a no-op. |
 | `android/app/build.gradle.kts` | `versionName` (semver) AND `versionCode` (monotonic int) | semver + integer | `versionName "1.0.1"`, `versionCode 2` → `versionName "1.0.2"`, `versionCode 3` | Only when files that ship in the Android app binary changed: `android/**`, OR any `shared/` path copied into app assets (today: `shared/content/**`, declared in the `copySharedContent` task in [android/app/build.gradle.kts](android/app/build.gradle.kts)). Surfaces in Play Console and Sentry Android dashboards. |
 
@@ -54,7 +56,9 @@ Before bumping, inspect the staged diff per platform. **Note that `shared/conten
 ```bash
 git diff --cached --stat -- web/ shared/content/
 git diff --cached --stat -- backend/
+git diff --cached --stat -- cli/
 git diff --cached --stat -- mcp/
+git diff --cached --stat -- sdk/
 git diff --cached --stat -- ios/ shared/content/
 git diff --cached --stat -- android/ shared/content/
 ```
@@ -64,6 +68,18 @@ If a directory shows no output, do **not** bump that platform's version. `packag
 A PR that touches **only** `shared/content/` (e.g. a copy fix on `about.md`) is a real release on every platform that bundles it: web users see a new build, iOS / Android users get an update via TestFlight / Play. The version files must reflect that. Skipping the bump on iOS / Android specifically can block the next upload because App Store Connect / Play Console reject duplicate `CFBundleVersion` / `versionCode`.
 
 For `web/`, the diff alone isn't enough: also check whether the changed files are user-facing (`web/src/**`, `web/styles/**`, `web/index.html`, `shared/content/**`) versus build-time tooling (`shared/design-tokens/**` exporters that emit to other platforms). Tooling-only diffs do not warrant a `web/package.json` bump.
+
+For package directories (`backend/`, `cli/`, `mcp/`, `sdk/`), treat any package-local source,
+test, CLI binary, config, or build wiring change as a package release unless it is clearly
+documentation-only. If the package behavior, build, generated types, tests, or published files
+change, bump that package.
+
+For platform apps (`ios/`, `android/`), treat app source, app resources, project/Gradle wiring,
+and shared bundled content as release-bearing. Do not dismiss a change as "cleanup" if it
+touches files that compile into, configure, or bundle the app.
+
+The pre-commit hook runs `npm run check:versions` against staged files. If it fails, bump the
+listed version files and stage them; do not bypass the check.
 
 If `ios/project.yml` `sources:` or `android/app/build.gradle.kts` `copySharedContent` (or the equivalent build glue) ever expands to consume more `shared/` paths, update this skill so the probes match the new reality.
 
@@ -201,7 +217,9 @@ Return the PR URL to the user.
 [ ] Bump root package.json (always)
 [ ] If user-facing web/ code OR shared/content/ changed: bump web/package.json
 [ ] If backend/ code changed: bump backend/package.json
+[ ] If cli/ code changed: bump cli/package.json
 [ ] If mcp/ code changed: bump mcp/package.json
+[ ] If sdk/ code changed: bump sdk/package.json
 [ ] If ios/ code OR shared/content/ changed: bump MARKETING_VERSION+CURRENT_PROJECT_VERSION
     in ios/project.yml AND CFBundleShortVersionString+CFBundleVersion in
     ios/MurphysLaws/Info.plist (lockstep)

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -14,6 +14,8 @@ if [ "$SKIP_CHANGELOG_CHECK" != "1" ]; then
   fi
 fi
 
+npm run check:versions
+
 # Reminders (only in interactive terminals)
 if [ -t 0 ]; then
   echo ""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - iOS skeleton-loading shimmer now consumes `DS.Color.mutedFg` (light + dark from the Asset Catalog) instead of hand-branching on `@Environment(\.colorScheme)` with hardcoded `Color(white:)` greys. [ios/MurphysLaws/Views/Home/SkeletonViews.swift](ios/MurphysLaws/Views/Home/SkeletonViews.swift). The dark-mode swap is now driven by the system trait collection via `Assets.xcassets/DS/muted-fg.colorset`, matching how every other DS color works. PR iOS-2 of the design-tokens-mobile rollout; calculator and vote-thumb surfaces are explicitly out of scope (HIG-idiomatic semantic colors `.green` / `.orange` / `.red` are correct on iOS), and no rank-style surface exists on iOS to migrate yet. iOS app bumped to `1.0.2` / build `3`; root to `2.4.17`.
 
 ### Fixed
+- Pre-commit now enforces required root, package, iOS, and Android version bumps
+  for staged release-bearing changes so ship metadata cannot be missed. Root bumped to `2.4.29`.
 - `shared/docs/SERVER_MAINTENANCE.md` corrected to match the live `murphys-main` server: the
   `sudo -i pm2 list` recipe (which fails because pm2 lives in root's nvm and is not on sudo's
   PATH) is replaced with a working `sudo bash -c "exec $(...)"` invocation that resolves the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.4.27",
+  "version": "2.4.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murphys-laws-monorepo",
-      "version": "2.4.27",
+      "version": "2.4.29",
       "license": "CC0-1.0",
       "workspaces": [
         "backend",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.4.28",
+  "version": "2.4.29",
   "description": "Murphy's Laws - Monorepo for Web, iOS, and Android apps",
   "private": true,
   "workspaces": [
@@ -46,6 +46,7 @@
     "validate:node-server": "cd backend && npm run validate:node-server",
     "validate-ports": "npx tsx backend/scripts/validate-ports.ts",
     "cleanup-ports": "npx tsx backend/scripts/cleanup-ports.ts",
+    "check:versions": "tsx scripts/check-version-bumps.ts",
     "install:all": "npm install && cd backend && npm install && cd ../web && npm install && cd ../sdk && npm install && cd ../cli && npm install && cd ../mcp && npm install",
     "design:sync": "tsx shared/design-tokens/sync-design-tokens.ts",
     "design:check": "tsx shared/design-tokens/sync-design-tokens.ts --check && tsx shared/design-tokens/design-md-lint.ts && tsx shared/design-tokens/export-ios-tokens.ts --check && tsx shared/design-tokens/export-android-tokens.ts --check && npm run design:test",

--- a/scripts/check-version-bumps.test.ts
+++ b/scripts/check-version-bumps.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+
+import { findMissingVersionBumps, parseStagedFiles } from './check-version-bumps';
+
+const versions = {
+  rootBefore: '{ "version": "1.0.0" }',
+  rootAfter: '{ "version": "1.0.1" }',
+  cliBefore: '{ "version": "0.1.0" }',
+  cliAfter: '{ "version": "0.1.1" }',
+  mcpBefore: '{ "version": "1.2.1" }',
+  mcpAfter: '{ "version": "1.2.2" }',
+  sdkBefore: '{ "version": "0.1.0" }',
+  sdkAfter: '{ "version": "0.1.1" }',
+  iosProjectBefore: 'MARKETING_VERSION: "1.1.3"\nCURRENT_PROJECT_VERSION: "7"\n',
+  iosProjectAfter: 'MARKETING_VERSION: "1.1.4"\nCURRENT_PROJECT_VERSION: "8"\n',
+  iosPlistBefore: '<key>CFBundleShortVersionString</key><string>1.1.3</string><key>CFBundleVersion</key><string>7</string>',
+  iosPlistAfter: '<key>CFBundleShortVersionString</key><string>1.1.4</string><key>CFBundleVersion</key><string>8</string>',
+};
+
+function missingFor(
+  stagedOutput: string,
+  afterOverrides: Record<string, string | null> = {},
+): string[] {
+  const beforeByPath: Record<string, string | null> = {
+    'package.json': versions.rootBefore,
+    'cli/package.json': versions.cliBefore,
+    'mcp/package.json': versions.mcpBefore,
+    'sdk/package.json': versions.sdkBefore,
+    'ios/project.yml': versions.iosProjectBefore,
+    'ios/MurphysLaws/Info.plist': versions.iosPlistBefore,
+  };
+  const afterByPath: Record<string, string | null> = {
+    'package.json': versions.rootBefore,
+    'cli/package.json': versions.cliBefore,
+    'mcp/package.json': versions.mcpBefore,
+    'sdk/package.json': versions.sdkBefore,
+    'ios/project.yml': versions.iosProjectBefore,
+    'ios/MurphysLaws/Info.plist': versions.iosPlistBefore,
+    ...afterOverrides,
+  };
+
+  return findMissingVersionBumps(
+    parseStagedFiles(stagedOutput),
+    (filePath) => beforeByPath[filePath] ?? null,
+    (filePath) => afterByPath[filePath] ?? null,
+  );
+}
+
+describe('check-version-bumps', () => {
+  it('requires CLI, MCP, and SDK package bumps when their package files change', () => {
+    const missing = missingFor(
+      [
+        'M\tpackage.json',
+        'M\tcli/src/index.ts',
+        'M\tmcp/src/server.ts',
+        'M\tsdk/src/index.ts',
+      ].join('\n'),
+      {
+        'package.json': versions.rootAfter,
+      },
+    );
+
+    expect(missing).toEqual([
+      'cli package: cli/package.json version',
+      'mcp package: mcp/package.json version',
+      'sdk package: sdk/package.json version',
+    ]);
+  });
+
+  it('passes package checks once the touched package versions are bumped', () => {
+    const missing = missingFor(
+      [
+        'M\tpackage.json',
+        'M\tcli/src/index.ts',
+        'M\tcli/package.json',
+        'M\tmcp/src/server.ts',
+        'M\tmcp/package.json',
+        'M\tsdk/src/index.ts',
+        'M\tsdk/package.json',
+      ].join('\n'),
+      {
+        'package.json': versions.rootAfter,
+        'cli/package.json': versions.cliAfter,
+        'mcp/package.json': versions.mcpAfter,
+        'sdk/package.json': versions.sdkAfter,
+      },
+    );
+
+    expect(missing).toEqual([]);
+  });
+
+  it('requires both iOS version files when iOS app source changes', () => {
+    const missing = missingFor(
+      [
+        'M\tpackage.json',
+        'M\tios/MurphysLaws/Views/More/MoreView.swift',
+      ].join('\n'),
+      {
+        'package.json': versions.rootAfter,
+      },
+    );
+
+    expect(missing).toEqual([
+      'iOS app: ios/project.yml marketing and build versions',
+      'iOS app: ios/MurphysLaws/Info.plist marketing and build versions',
+    ]);
+  });
+
+  it('passes iOS checks when project.yml and Info.plist both bump marketing and build versions', () => {
+    const missing = missingFor(
+      [
+        'M\tpackage.json',
+        'M\tios/MurphysLaws/Views/More/MoreView.swift',
+        'M\tios/project.yml',
+        'M\tios/MurphysLaws/Info.plist',
+      ].join('\n'),
+      {
+        'package.json': versions.rootAfter,
+        'ios/project.yml': versions.iosProjectAfter,
+        'ios/MurphysLaws/Info.plist': versions.iosPlistAfter,
+      },
+    );
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/scripts/check-version-bumps.ts
+++ b/scripts/check-version-bumps.ts
@@ -1,0 +1,264 @@
+import { execFileSync } from 'node:child_process';
+
+type VersionFile = {
+  path: string;
+  label: string;
+  hasVersionBump: (before: string | null, after: string | null) => boolean;
+};
+
+type VersionRule = {
+  name: string;
+  trigger: (filePath: string) => boolean;
+  versionFiles: VersionFile[];
+};
+
+type StagedFile = {
+  path: string;
+  status: string;
+};
+
+const ignoredRootFiles = new Set([
+  'CHANGELOG.md',
+  'package-lock.json',
+  'package.json',
+]);
+
+const versionFilePaths = new Set([
+  'backend/package.json',
+  'cli/package.json',
+  'mcp/package.json',
+  'sdk/package.json',
+  'web/package.json',
+  'ios/project.yml',
+  'ios/MurphysLaws/Info.plist',
+  'ios/MurphysLaws.xcodeproj/project.pbxproj',
+  'android/app/build.gradle.kts',
+]);
+
+const documentationExtensions = new Set(['.md', '.markdown', '.txt']);
+
+function isDocumentationOnly(filePath: string): boolean {
+  const lowerPath = filePath.toLowerCase();
+  return [...documentationExtensions].some((extension) => lowerPath.endsWith(extension));
+}
+
+function isRootReleaseBearing(filePath: string): boolean {
+  return !ignoredRootFiles.has(filePath) && !versionFilePaths.has(filePath);
+}
+
+function isPackageReleaseBearing(prefix: string, filePath: string): boolean {
+  return filePath.startsWith(prefix) && !versionFilePaths.has(filePath) && !isDocumentationOnly(filePath);
+}
+
+function isPlatformReleaseBearing(prefix: string, filePath: string): boolean {
+  return filePath.startsWith(prefix) && !versionFilePaths.has(filePath) && !isDocumentationOnly(filePath);
+}
+
+function parseJsonVersion(content: string | null): string | null {
+  if (content === null) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(content) as { version?: unknown };
+    return typeof parsed.version === 'string' ? parsed.version : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseRegexValue(content: string | null, regex: RegExp): string | null {
+  if (content === null) {
+    return null;
+  }
+
+  return regex.exec(content)?.[1] ?? null;
+}
+
+function hasJsonVersionBump(before: string | null, after: string | null): boolean {
+  const beforeVersion = parseJsonVersion(before);
+  const afterVersion = parseJsonVersion(after);
+
+  return beforeVersion !== null && afterVersion !== null && beforeVersion !== afterVersion;
+}
+
+function hasIosProjectVersionBump(before: string | null, after: string | null): boolean {
+  const beforeMarketing = parseRegexValue(before, /MARKETING_VERSION:\s*["']?([^"'\n]+)["']?/);
+  const afterMarketing = parseRegexValue(after, /MARKETING_VERSION:\s*["']?([^"'\n]+)["']?/);
+  const beforeBuild = parseRegexValue(before, /CURRENT_PROJECT_VERSION:\s*["']?([^"'\n]+)["']?/);
+  const afterBuild = parseRegexValue(after, /CURRENT_PROJECT_VERSION:\s*["']?([^"'\n]+)["']?/);
+
+  return Boolean(
+    beforeMarketing && afterMarketing && beforeMarketing !== afterMarketing &&
+      beforeBuild && afterBuild && beforeBuild !== afterBuild,
+  );
+}
+
+function hasIosInfoPlistVersionBump(before: string | null, after: string | null): boolean {
+  const beforeMarketing = parseRegexValue(
+    before,
+    /<key>CFBundleShortVersionString<\/key>\s*<string>([^<]+)<\/string>/,
+  );
+  const afterMarketing = parseRegexValue(
+    after,
+    /<key>CFBundleShortVersionString<\/key>\s*<string>([^<]+)<\/string>/,
+  );
+  const beforeBuild = parseRegexValue(before, /<key>CFBundleVersion<\/key>\s*<string>([^<]+)<\/string>/);
+  const afterBuild = parseRegexValue(after, /<key>CFBundleVersion<\/key>\s*<string>([^<]+)<\/string>/);
+
+  return Boolean(
+    beforeMarketing && afterMarketing && beforeMarketing !== afterMarketing &&
+      beforeBuild && afterBuild && beforeBuild !== afterBuild,
+  );
+}
+
+function hasAndroidVersionBump(before: string | null, after: string | null): boolean {
+  const beforeName = parseRegexValue(before, /versionName\s*=\s*"([^"]+)"/);
+  const afterName = parseRegexValue(after, /versionName\s*=\s*"([^"]+)"/);
+  const beforeCode = parseRegexValue(before, /versionCode\s*=\s*(\d+)/);
+  const afterCode = parseRegexValue(after, /versionCode\s*=\s*(\d+)/);
+
+  return Boolean(beforeName && afterName && beforeName !== afterName && beforeCode && afterCode && beforeCode !== afterCode);
+}
+
+export const versionRules: VersionRule[] = [
+  {
+    name: 'root package',
+    trigger: isRootReleaseBearing,
+    versionFiles: [
+      { path: 'package.json', label: 'root package.json version', hasVersionBump: hasJsonVersionBump },
+    ],
+  },
+  {
+    name: 'web package',
+    trigger: (filePath) => isPackageReleaseBearing('web/', filePath) || filePath.startsWith('shared/content/'),
+    versionFiles: [
+      { path: 'web/package.json', label: 'web/package.json version', hasVersionBump: hasJsonVersionBump },
+    ],
+  },
+  {
+    name: 'backend package',
+    trigger: (filePath) => isPackageReleaseBearing('backend/', filePath),
+    versionFiles: [
+      { path: 'backend/package.json', label: 'backend/package.json version', hasVersionBump: hasJsonVersionBump },
+    ],
+  },
+  {
+    name: 'cli package',
+    trigger: (filePath) => isPackageReleaseBearing('cli/', filePath),
+    versionFiles: [
+      { path: 'cli/package.json', label: 'cli/package.json version', hasVersionBump: hasJsonVersionBump },
+    ],
+  },
+  {
+    name: 'mcp package',
+    trigger: (filePath) => isPackageReleaseBearing('mcp/', filePath),
+    versionFiles: [
+      { path: 'mcp/package.json', label: 'mcp/package.json version', hasVersionBump: hasJsonVersionBump },
+    ],
+  },
+  {
+    name: 'sdk package',
+    trigger: (filePath) => isPackageReleaseBearing('sdk/', filePath),
+    versionFiles: [
+      { path: 'sdk/package.json', label: 'sdk/package.json version', hasVersionBump: hasJsonVersionBump },
+    ],
+  },
+  {
+    name: 'iOS app',
+    trigger: (filePath) => isPlatformReleaseBearing('ios/', filePath) || filePath.startsWith('shared/content/'),
+    versionFiles: [
+      { path: 'ios/project.yml', label: 'ios/project.yml marketing and build versions', hasVersionBump: hasIosProjectVersionBump },
+      {
+        path: 'ios/MurphysLaws/Info.plist',
+        label: 'ios/MurphysLaws/Info.plist marketing and build versions',
+        hasVersionBump: hasIosInfoPlistVersionBump,
+      },
+    ],
+  },
+  {
+    name: 'Android app',
+    trigger: (filePath) => isPlatformReleaseBearing('android/', filePath) || filePath.startsWith('shared/content/'),
+    versionFiles: [
+      {
+        path: 'android/app/build.gradle.kts',
+        label: 'android/app/build.gradle.kts versionName and versionCode',
+        hasVersionBump: hasAndroidVersionBump,
+      },
+    ],
+  },
+];
+
+export function parseStagedFiles(output: string): StagedFile[] {
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [status, ...pathParts] = line.split(/\s+/);
+      return { status, path: pathParts[pathParts.length - 1] };
+    });
+}
+
+export function findMissingVersionBumps(
+  stagedFiles: StagedFile[],
+  readBefore: (filePath: string) => string | null,
+  readAfter: (filePath: string) => string | null,
+): string[] {
+  const changedPaths = stagedFiles.map((file) => file.path);
+  const impactedRules = versionRules.filter((rule) => changedPaths.some(rule.trigger));
+  const missing: string[] = [];
+
+  for (const rule of impactedRules) {
+    for (const versionFile of rule.versionFiles) {
+      if (!versionFile.hasVersionBump(readBefore(versionFile.path), readAfter(versionFile.path))) {
+        missing.push(`${rule.name}: ${versionFile.label}`);
+      }
+    }
+  }
+
+  return missing;
+}
+
+function git(args: string[]): string {
+  return execFileSync('git', args, { encoding: 'utf8' });
+}
+
+function readFromHead(filePath: string): string | null {
+  try {
+    return git(['show', `HEAD:${filePath}`]);
+  } catch {
+    return null;
+  }
+}
+
+function readFromIndex(filePath: string): string | null {
+  try {
+    return git(['show', `:${filePath}`]);
+  } catch {
+    return null;
+  }
+}
+
+function main(): void {
+  const stagedFiles = parseStagedFiles(git(['diff', '--cached', '--name-status', '--diff-filter=ACMRTD']));
+  const missing = findMissingVersionBumps(stagedFiles, readFromHead, readFromIndex);
+
+  if (missing.length === 0) {
+    return;
+  }
+
+  console.error('');
+  console.error('ERROR: Staged changes require version bumps.');
+  console.error('');
+  for (const item of missing) {
+    console.error(`- ${item}`);
+  }
+  console.error('');
+  console.error('Update the listed version files, stage them, and retry the commit.');
+  process.exit(1);
+}
+
+if (process.argv[1]?.endsWith('check-version-bumps.ts')) {
+  main();
+}


### PR DESCRIPTION
## Summary

- Updates the ship skill to include CLI and SDK package version bumps alongside existing web, backend, MCP, iOS, and Android rules.
- Adds a pre-commit `check:versions` guard that fails when staged release-bearing changes are missing required package or platform version bumps.
- Covers the checker with focused tests for CLI/MCP/SDK and iOS version requirements.

## Test plan

- [x] `npx vitest run scripts/check-version-bumps.test.ts`
- [x] `npm run check:versions`
- [x] Pre-commit hook completed: backend checks, web checks, backend/web coverage, web E2E, coverage threshold check, lint-staged

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ravidorr/murphys-laws/109)
<!-- Reviewable:end -->
