### PR TITLE
chore: add share action to iOS law cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Work Sans variable font bundled in the Android app for visual parity with web. [android/app/src/main/res/font/work_sans_variable.ttf](android/app/src/main/res/font/work_sans_variable.ttf) (~360 KB, single VF covers all weights via the `wght` axis), wrapped by a hand-authored `WorkSans` `FontFamily` in [android/app/src/main/java/com/murphyslaws/ui/theme/WorkSans.kt](android/app/src/main/java/com/murphyslaws/ui/theme/WorkSans.kt). The FontFamily registers the variable font at four weight slots (Normal 400, Medium 500, SemiBold 600, Bold 700) with `FontVariation.Settings(FontVariation.weight(...))` so Compose's typography system resolves `.weight(...)` requests to the correct axis position. Requires API 26+, which matches the app's `minSdk`. [shared/design-tokens/export-android-tokens.ts](shared/design-tokens/export-android-tokens.ts) now emits `fontFamily = WorkSans` for every `DS.Typography.<level>`, replacing the `FontFamily.Default` (Roboto) placeholder from PR Android-1. PR Android-3 (final phase) of the design-tokens-mobile rollout. Bundling a new font is user-visible, so Android app bumped MINOR to `1.1.0` / versionCode `4`; root to `2.4.23`.
 
 ### Changed
+- iOS law cards now keep footer controls aligned and include a share action in
+  the vote row instead of a category pill. iOS app bumped to `1.1.10` / build
+  `14`; root to `2.4.36`.
 - iOS submit-law category selection now uses the same category row treatment as
   browsing and filters. iOS app bumped to `1.1.7` / build `11`; root to
   `2.4.33`.

--- a/ios/MurphysLaws.xcodeproj/project.pbxproj
+++ b/ios/MurphysLaws.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		DFF8022A2357108FCAD99EF0 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 125081ED09FD2AC2BF948058 /* Logger.swift */; };
 		E60F251C221AF42EA0C86F80 /* Config.plist in Resources */ = {isa = PBXBuildFile; fileRef = 802D6D49BE09E472F3916020 /* Config.plist */; };
 		EC9526CC7C7A4F04282B2FCC /* DateFormatters.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6DB5EC23A4BAA854110169 /* DateFormatters.swift */; };
+		EF2E1636DA3AF7611C9D8B6D /* LawCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5584840A11D03F1F1E2A7D97 /* LawCardTests.swift */; };
 		F8BEFE8D710B14865363242D /* SearchAndFilterUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C0F3DDC9B54E0D329D3602 /* SearchAndFilterUITests.swift */; };
 /* End PBXBuildFile section */
 
@@ -137,6 +138,7 @@
 		52E7F37A98F3CA8F2BD0F4D9 /* CalculatorUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatorUITests.swift; sourceTree = "<group>"; };
 		535B04B1531B0D7550DD7476 /* FilterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterView.swift; sourceTree = "<group>"; };
 		54899E03EF2404EFAC953259 /* DesignSystemViewModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystemViewModifiers.swift; sourceTree = "<group>"; };
+		5584840A11D03F1F1E2A7D97 /* LawCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LawCardTests.swift; sourceTree = "<group>"; };
 		55B4A796B4499D025053AB61 /* ImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
 		5B496C30B4D01E873AC35F4A /* MurphysLawsTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = MurphysLawsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5DA9B5B613B0E7969E41C543 /* Attribution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Attribution.swift; sourceTree = "<group>"; };
@@ -246,7 +248,7 @@
 			);
 			sourceTree = "<group>";
 		};
-		292D8E672F9EA6020076B643 /* Products */ = {
+		292D8E772F9EA9D40076B643 /* Products */ = {
 			isa = PBXGroup;
 			children = (
 			);
@@ -348,6 +350,7 @@
 				1B5D9214B6274780F3522A9A /* ConfigurationTests.swift */,
 				4541A481E11F081CB97C844D /* DeepLinkHandlerTests.swift */,
 				C39071912628B8D7170205D3 /* HomeViewModelTests.swift */,
+				5584840A11D03F1F1E2A7D97 /* LawCardTests.swift */,
 				6569FD09C0F96A98703D66FF /* LawIntegrationTests.swift */,
 				1999A69F6DE44010272F8C39 /* LawListViewModelTests.swift */,
 				2C701DDAFDC7AC488AB74994 /* MockLawRepository.swift */,
@@ -552,7 +555,7 @@
 			projectDirPath = "";
 			projectReferences = (
 				{
-					ProductGroup = 292D8E672F9EA6020076B643 /* Products */;
+					ProductGroup = 292D8E772F9EA9D40076B643 /* Products */;
 					ProjectRef = 0A4A458B2333FBA01D004AED /* MurphysLaws.xcodeproj */;
 				},
 			);
@@ -613,6 +616,7 @@
 				6891D05E8E23DC16A876B5F3 /* ConfigurationTests.swift in Sources */,
 				6B10B13B7AE06BF0E117BC81 /* DeepLinkHandlerTests.swift in Sources */,
 				7C64A32048B746BB8334CB22 /* HomeViewModelTests.swift in Sources */,
+				EF2E1636DA3AF7611C9D8B6D /* LawCardTests.swift in Sources */,
 				5D6B2A234AEB61C786DB68FD /* LawIntegrationTests.swift in Sources */,
 				785A84043E4DE8B70F1FCBF2 /* LawListViewModelTests.swift in Sources */,
 				040DD852D753272B9EF61599 /* MarkdownContentTests.swift in Sources */,
@@ -760,7 +764,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -779,7 +783,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 1.1.9;
+				MARKETING_VERSION = 1.1.10;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -901,7 +905,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 13;
+				CURRENT_PROJECT_VERSION = 14;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -914,7 +918,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				MARKETING_VERSION = 1.1.9;
+				MARKETING_VERSION = 1.1.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ios/MurphysLaws/Info.plist
+++ b/ios/MurphysLaws/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.9</string>
+	<string>1.1.10</string>
 	<key>CFBundleVersion</key>
-	<string>13</string>
+	<string>14</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>Save and share Murphy's Laws as images</string>
 	<key>UIAppFonts</key>

--- a/ios/MurphysLaws/Views/Shared/LawCard.swift
+++ b/ios/MurphysLaws/Views/Shared/LawCard.swift
@@ -32,33 +32,28 @@ struct LawCard: View {
                 .foregroundColor(DS.Color.mutedFg)
                 .lineLimit(4)
 
-            // Vote counts and categories
+            Spacer(minLength: 0)
+
+            // Vote counts and share
             HStack {
-                // Upvotes
                 Label("\(law.upvotes)", systemImage: currentVote == .up ? "hand.thumbsup.fill" : "hand.thumbsup")
                     .foregroundColor(currentVote == .up ? DS.Color.success : DS.Color.mutedFg)
                     .dsTypography(DS.Typography.caption)
 
-                // Downvotes
                 Label("\(law.downvotes)", systemImage: currentVote == .down ? "hand.thumbsdown.fill" : "hand.thumbsdown")
                     .foregroundColor(currentVote == .down ? DS.Color.error : DS.Color.mutedFg)
                     .dsTypography(DS.Typography.caption)
 
                 Spacer()
 
-                // Category tags (first one only for card)
-                if let firstCategory = law.categories?.first {
-                    Text(firstCategory.title)
+                ShareLink(item: law.shareText) {
+                    Label("Share", systemImage: "square.and.arrow.up")
                         .dsTypography(DS.Typography.caption)
-                        .padding(.horizontal, Constants.UI.spacingS)
-                        .padding(.vertical, 4)
-                        .background(firstCategory.iconColor.opacity(0.2))
-                        .foregroundColor(firstCategory.iconColor)
-                        .cornerRadius(Constants.UI.cornerRadiusS)
                 }
             }
         }
         .padding()
+        .frame(maxHeight: .infinity, alignment: .top)
         .background(DS.Color.surface)
         .cornerRadius(Constants.UI.cornerRadiusM)
         .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)

--- a/ios/MurphysLawsTests/LawCardTests.swift
+++ b/ios/MurphysLawsTests/LawCardTests.swift
@@ -1,0 +1,32 @@
+//
+//  LawCardTests.swift
+//  MurphysLawsTests
+//
+//  Tests for reusable law card styling contracts
+//
+
+import XCTest
+
+final class LawCardTests: XCTestCase {
+
+    func testLawCardFooterUsesShareActionInsteadOfCategoryPill() throws {
+        let sourceURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("MurphysLaws/Views/Shared/LawCard.swift")
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+        XCTAssertTrue(
+            source.contains("ShareLink(item: law.shareText)"),
+            "Law cards should expose sharing from the footer row"
+        )
+        XCTAssertTrue(
+            source.contains(".frame(maxHeight: .infinity, alignment: .top)"),
+            "Law card contents should stay top-aligned when cards share a row height"
+        )
+        XCTAssertFalse(
+            source.contains("if let firstCategory = law.categories?.first"),
+            "Law cards should not reserve the footer trailing slot for a category pill"
+        )
+    }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -7,8 +7,8 @@ options:
   xcodeVersion: "14.0"
 
 settings:
-  MARKETING_VERSION: "1.1.9"
-  CURRENT_PROJECT_VERSION: "13"
+  MARKETING_VERSION: "1.1.10"
+  CURRENT_PROJECT_VERSION: "14"
 
 targets:
   MurphysLaws:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.4.35",
+  "version": "2.4.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murphys-laws-monorepo",
-      "version": "2.4.35",
+      "version": "2.4.36",
       "license": "CC0-1.0",
       "workspaces": [
         "backend",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.4.35",
+  "version": "2.4.36",
   "description": "Murphy's Laws - Monorepo for Web, iOS, and Android apps",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Summary

- Replaces the iOS law card category pill with a share action in the footer row.
- Keeps law card content top-aligned when cards share row height and bumps root/iOS release metadata.

## Test plan

- [x] xcodegen generate && xcodebuild test -project MurphysLaws.xcodeproj -scheme MurphysLaws -destination "platform=iOS Simulator,id=<local simulator>" -only-testing:MurphysLawsTests/LawCardTests
- [x] npm run check:versions
- [x] npm run lint:md -- CHANGELOG.md
- [x] Pre-commit hook: backend/web checks, coverage, and web E2E

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ravidorr/murphys-laws/114)
<!-- Reviewable:end -->
