### PR TITLE
feat(web): improve site audit surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Work Sans variable font bundled in the Android app for visual parity with web. [android/app/src/main/res/font/work_sans_variable.ttf](android/app/src/main/res/font/work_sans_variable.ttf) (~360 KB, single VF covers all weights via the `wght` axis), wrapped by a hand-authored `WorkSans` `FontFamily` in [android/app/src/main/java/com/murphyslaws/ui/theme/WorkSans.kt](android/app/src/main/java/com/murphyslaws/ui/theme/WorkSans.kt). The FontFamily registers the variable font at four weight slots (Normal 400, Medium 500, SemiBold 600, Bold 700) with `FontVariation.Settings(FontVariation.weight(...))` so Compose's typography system resolves `.weight(...)` requests to the correct axis position. Requires API 26+, which matches the app's `minSdk`. [shared/design-tokens/export-android-tokens.ts](shared/design-tokens/export-android-tokens.ts) now emits `fontFamily = WorkSans` for every `DS.Typography.<level>`, replacing the `FontFamily.Default` (Roboto) placeholder from PR Android-1. PR Android-3 (final phase) of the design-tokens-mobile rollout. Bundling a new font is user-visible, so Android app bumped MINOR to `1.1.0` / versionCode `4`; root to `2.4.23`.
 
 ### Changed
+- Web site audit surfaces now render useful static content for core internal
+  routes, including homepage, developers, favorites, submit, calculators,
+  categories, and law detail pages. The archive experience now has richer law
+  detail context, grouped category hubs, stronger origin/examples content,
+  canonical calculator structured data, and privacy-safe product metrics.
+  Web bumped to `3.2.13`; iOS app bumped to `1.1.11` / build `15`;
+  Android app bumped to `1.1.2` / versionCode `6`; root to `2.4.38`.
 - iOS law cards now keep footer controls aligned and include a share action in
   the vote row instead of a category pill. iOS app bumped to `1.1.10` / build
   `14`; root to `2.4.36`.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -17,8 +17,8 @@ android {
         applicationId = "com.murphyslaws"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5
-        versionName = "1.1.1"
+        versionCode = 6
+        versionName = "1.1.2"
 
         testInstrumentationRunner = "com.murphyslaws.CustomTestRunner"
         vectorDrawables {

--- a/ios/MurphysLaws/Info.plist
+++ b/ios/MurphysLaws/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.10</string>
+	<string>1.1.11</string>
 	<key>CFBundleVersion</key>
-	<string>14</string>
+	<string>15</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>Save and share Murphy's Laws as images</string>
 	<key>UIAppFonts</key>

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -7,8 +7,8 @@ options:
   xcodeVersion: "14.0"
 
 settings:
-  MARKETING_VERSION: "1.1.10"
-  CURRENT_PROJECT_VERSION: "14"
+  MARKETING_VERSION: "1.1.11"
+  CURRENT_PROJECT_VERSION: "15"
 
 targets:
   MurphysLaws:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.4.36",
+  "version": "2.4.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murphys-laws-monorepo",
-      "version": "2.4.36",
+      "version": "2.4.38",
       "license": "CC0-1.0",
       "workspaces": [
         "backend",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.4.37",
+  "version": "2.4.38",
   "description": "Murphy's Laws - Monorepo for Web, iOS, and Android apps",
   "private": true,
   "workspaces": [

--- a/shared/content/examples.md
+++ b/shared/content/examples.md
@@ -13,6 +13,8 @@ Your phone maintains a healthy charge all day while sitting unused on your desk.
 ### The Update Curse
 Critical software updates always seem to install themselves right when you're about to give an important presentation. The loading bar moves at a glacial pace, seemingly aware of your mounting anxiety.
 
+Explore more failures in [Murphy's Technology Laws](/category/murphys-technology-laws) and [Murphy's Computer Laws](/category/murphys-computer-laws).
+
 ## Work and Career Examples
 
 ### The Interview Outfit
@@ -23,6 +25,8 @@ Your phone connection is crystal clear all day. The moment an important client c
 
 ### The Email Timing
 You finally send that carefully crafted email after hours of editing. Within seconds, you notice a glaring typo in the subject line or realize you hit "Reply All" instead of "Reply."
+
+Work examples connect directly to [Murphy's Office Laws](/category/murphys-office-laws) and the project risk patterns in [Project Management vs. The Universe](/murphys-law-project-management).
 
 ## Everyday Life Examples
 
@@ -38,6 +42,8 @@ When you're running late, every traffic light turns red as you approach. When yo
 ### The Checkout Line
 Whichever line you choose at the grocery store will be the slowest. The moment you switch to another line, your original line starts moving faster.
 
+For more ordinary trouble, start with [Murphy's Alarm Clock Laws](/category/murphys-alarm-clock-laws), [Murphy's Mothers Laws](/category/murphys-mothers-laws), and the full [category directory](/categories).
+
 ## Murphy's Law in Travel
 
 ### The Baggage Claim
@@ -48,6 +54,18 @@ You plan an outdoor event months in advance, carefully selecting a date with his
 
 ### The Flight Connection
 Your first flight will be delayed just long enough to make you miss your connecting flight, which departed on time for the first time in its history.
+
+Travel patterns continue in [Murphy's Travel Laws](/category/murphys-travel-laws), [Murphy's Bus Laws](/category/murphys-bus-laws), and [Murphy's Cars Laws](/category/murphys-cars-laws).
+
+## How to Reduce the Chance of It Happening
+
+Murphy's Law is useful when it changes behavior. Treat each example as a prompt:
+
+- Remove time pressure before it compounds small mistakes.
+- Make important steps visible, reversible, or impossible to skip.
+- Keep backups for tools, routes, batteries, files, and people.
+- Assume communication will be misunderstood and confirm the critical details.
+- Design the system so the most likely mistake is easy to catch.
 
 ## The Science Behind Murphy's Law
 

--- a/shared/content/origin-story.md
+++ b/shared/content/origin-story.md
@@ -16,11 +16,34 @@ Frustrated by this setback, Murphy reportedly uttered his now-famous dictum. Acc
 
 Dr. John Stapp, recognizing the profound truth and practical application of Murphy's observation, began quoting "Murphy's Law" at press conferences, explaining how the principle was crucial to the safety programs and zero-tolerance-for-error philosophy at the base. From there, it spread rapidly through the scientific and engineering communities, eventually permeating popular culture.
 
+## Timeline
+
+- **1949:** Project MX981 rocket-sled tests expose the accelerometer installation error at Edwards Air Force Base.
+- **Late 1940s:** Murphy's wording circulates inside the test program as a design warning, not just a joke.
+- **1950s:** John Stapp repeats the phrase publicly while explaining the safety mindset behind the tests.
+- **Later decades:** Engineers, soldiers, programmers, travelers, and office workers adapt the law into field-specific corollaries.
+
+## Myth vs Fact
+
+**Myth:** Murphy's Law began as fatalism.
+
+**Fact:** The original lesson was practical engineering: if a component can be installed incorrectly, design the system so incorrect installation is impossible or obvious.
+
+**Myth:** The exact modern wording was recorded immediately.
+
+**Fact:** The wording varies by source. The consistent core is that foreseeable misuse should be designed out before it becomes a failure.
+
 ## Evolution and Cultural Impact
 
 Over the decades, Murphy's Law evolved, spawning countless corollaries and variations that apply to nearly every facet of life - from computing ("The one you need is the one you haven't backed up") to queuing ("The other line always moves faster"). It became a shorthand for acknowledging life's inherent unpredictability and the perverse tendency of things to go awry at the most inconvenient times.
 
 While often invoked with a chuckle or a sigh, at its core, Murphy's Law serves as a constant, if darkly humorous, reminder to anticipate failure, plan for contingencies, and design with robustness in mind. It's a testament to the lasting impact of a frustrated engineer's observation, highlighting the human capacity to find meaning and even humor in the face of inevitable mishaps.
+
+## Start Exploring
+
+- Browse [technology laws](/category/murphys-technology-laws) for modern versions of the same design lesson.
+- Read [real-life Murphy's Law examples](/examples) to see how the pattern shows up at work, in travel, and in everyday life.
+- Try the [Sod's Law Calculator](/calculator/sods-law) when you want to model why pressure, complexity, and timing make failures feel inevitable.
 
 ## Source notes
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-web",
-  "version": "3.2.12",
+  "version": "3.2.13",
   "description": "Murphy's Laws Web Application",
   "type": "module",
   "scripts": {

--- a/web/scripts/ssg.ts
+++ b/web/scripts/ssg.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { marked } from 'marked';
 import { generateCategoryDescription } from '../src/utils/content-generator.ts';
+import { groupCategories } from '../src/utils/category-groups.ts';
 import { truncateTitle } from '../src/utils/seo.ts';
 interface LawAttribution { name?: string; contact_type?: string; contact_value?: string; note?: string }
 interface Law {
@@ -10,6 +11,11 @@ interface Law {
   title?: string;
   text?: string;
   attributions?: LawAttribution[];
+  attribution?: string;
+  author?: string;
+  category_slug?: string;
+  category_name?: string;
+  category_context?: string | null;
   upvotes?: number;
   downvotes?: number;
   created_at?: string;
@@ -82,6 +88,12 @@ const CONTENT_PAGES: ContentPageMeta[] = [
     file: 'murphys-law-project-management.md',
     title: 'Project Management vs. The Universe: A Survival Guide',
     description: 'Plan for failure, tame scope creep, and assume you are being misunderstood. A survival guide to applying Murphy\'s Law in project management.'
+  },
+  {
+    slug: 'developers',
+    file: 'developers.md',
+    title: 'Developers',
+    description: 'REST API, MCP server, TypeScript SDK, CLI, and machine-readable feeds for Murphy\'s Law Archive.'
   }
 ];
 
@@ -186,6 +198,83 @@ function escapeHtml(text: string): string {
     .replace(/'/g, '&#039;');
 }
 
+function getLawAttributionName(law: Law): string | null {
+  if (law.attributions && law.attributions.length > 0 && law.attributions[0]?.name) {
+    return law.attributions[0].name;
+  }
+  return law.author || law.attribution || null;
+}
+
+function buildStaticLawDetailContent(law: Law): string {
+  const title = law.title || "Murphy's Law";
+  const attributionName = getLawAttributionName(law);
+  const sourceStatus = attributionName
+    ? `Attributed to ${escapeHtml(attributionName)}`
+    : 'Source not yet verified by the archive.';
+  const categoryName = law.category_name || 'Murphy\'s Laws';
+  const categorySlug = law.category_slug;
+  const categoryLink = categorySlug
+    ? `<a href="/category/${escapeHtml(categorySlug)}">${escapeHtml(categoryName)}</a>`
+    : `<a href="/categories">Browse categories</a>`;
+  const context = law.category_context
+    || `This law belongs with ${categoryName}, where small assumptions, timing, and system complexity tend to turn into memorable failures.`;
+  const upvotes = Number.isFinite(law.upvotes) ? law.upvotes : 0;
+  const downvotes = Number.isFinite(law.downvotes) ? law.downvotes : 0;
+
+  return `
+    <div class="container page law-detail pt-0">
+      <nav class="breadcrumb" aria-label="Breadcrumb">
+        <ol>
+          <li><a href="/">Home</a></li>
+          <li><a href="/browse">Browse</a></li>
+          <li aria-current="page">${escapeHtml(title)}</li>
+        </ol>
+      </nav>
+      <article class="law-detail-card card">
+        <header class="card-header">
+          <h1 class="card-title">${escapeHtml(title)}</h1>
+          <p class="small">Source status: ${sourceStatus}</p>
+        </header>
+        <div class="card-body">
+          <blockquote class="law-text">${escapeHtml(law.text || '')}</blockquote>
+          ${attributionName ? `<p class="attribution">- ${escapeHtml(attributionName)}</p>` : ''}
+          <div class="law-meta">
+            <p><strong>Category:</strong> ${categoryLink}</p>
+            <p><strong>Votes:</strong> ${upvotes} up, ${downvotes} down</p>
+          </div>
+        </div>
+      </article>
+      <section class="section section-card mb-12" aria-labelledby="law-context-heading">
+        <div class="section-header">
+          <h2 id="law-context-heading" class="section-title" data-section-title="In context"><span class="accent-text">In</span> context</h2>
+        </div>
+        <div class="section-body">
+          <p>${escapeHtml(context)}</p>
+        </div>
+      </section>
+      <section class="section section-card mb-12" aria-labelledby="related-laws-heading">
+        <div class="section-header">
+          <h2 id="related-laws-heading" class="section-title" data-section-title="Related laws"><span class="accent-text">Related</span> laws</h2>
+        </div>
+        <div class="section-body">
+          <p>Keep exploring laws from this topic or browse the full archive for neighboring ideas.</p>
+          <div class="not-found-actions">
+            ${categorySlug ? `<a href="/category/${escapeHtml(categorySlug)}" class="btn">See this category</a>` : ''}
+            <a href="/browse" class="btn outline">Browse all laws</a>
+          </div>
+        </div>
+      </section>
+      <section class="section section-card" aria-labelledby="law-actions-heading">
+        <div class="section-header">
+          <h2 id="law-actions-heading" class="section-title"><span class="accent-text">Improve</span> this entry</h2>
+        </div>
+        <div class="section-body">
+          <p>Know the original source, a better attribution, or a duplicate we should merge? <a href="/contact">Report an issue</a>.</p>
+        </div>
+      </section>
+    </div>`;
+}
+
 /**
  * Update hreflang tags to point to the correct URL
  */
@@ -285,31 +374,10 @@ function generateLawPage(law: Law, template: string): string {
   );
   
   // Get attribution name
-  const attributionName = law.attributions && law.attributions.length > 0
-    ? (law.attributions[0]?.name ?? null)
-    : null;
-  
-  // Split title for accent styling
-  const safeTitle = title ?? "Murphy's Law";
-  const titleWords = safeTitle.split(' ');
-  const accentTitle = titleWords.length > 1
-    ? `<span class="accent-text">${escapeHtml(titleWords[0] ?? '')}</span> ${escapeHtml(titleWords.slice(1).join(' '))}`
-    : `<span class="accent-text">${escapeHtml(safeTitle)}</span>`;
-  
+  const attributionName = getLawAttributionName(law);
+
   // Build static content for law detail page
-  const staticContent = `
-    <div class="container page law-detail pt-0">
-      <article class="law-detail-card card">
-        <header class="card-header">
-          <h1 class="card-title">${accentTitle}</h1>
-        </header>
-        <div class="card-body">
-          <blockquote class="law-text">${escapeHtml(law.text || '')}</blockquote>
-          ${attributionName ? `<p class="attribution">- ${escapeHtml(attributionName)}</p>` : ''}
-        </div>
-      </article>
-    </div>
-`;
+  const staticContent = buildStaticLawDetailContent(law);
   
   // Inject content into main
   pageHtml = pageHtml.replace(
@@ -348,6 +416,33 @@ function generateLawPage(law: Law, template: string): string {
   });
   
   pageHtml = injectJsonLd(pageHtml, lawJsonLd);
+
+  const breadcrumbJsonLd = generateJsonLd({
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    'itemListElement': [
+      {
+        '@type': 'ListItem',
+        'position': 1,
+        'name': 'Home',
+        'item': SITE_URL
+      },
+      {
+        '@type': 'ListItem',
+        'position': 2,
+        'name': 'Browse',
+        'item': `${SITE_URL}/browse`
+      },
+      {
+        '@type': 'ListItem',
+        'position': 3,
+        'name': title,
+        'item': lawUrl
+      }
+    ]
+  });
+
+  pageHtml = injectJsonLd(pageHtml, breadcrumbJsonLd);
   
   return pageHtml;
 }
@@ -449,6 +544,165 @@ ${headerHtml}
             ${bodyContent.trim()}
           </div>
         </article>`;
+}
+
+function buildStaticFavoritesContent(): string {
+  return `
+    <div class="container page">
+      <h1 class="page-title mb-4" data-page-title="My Favorites"><span class="accent-text">My</span> Favorites</h1>
+      <article class="card content-card">
+        <header class="card-header text-center">
+          <h2 class="card-title"><span class="accent-text">Save</span> Laws You Want To Revisit</h2>
+          <blockquote class="not-found-quote">
+            "The law you need most will be the one you forgot to save."
+          </blockquote>
+          <p class="text-muted-fg">Favorites are stored in your browser on this device. No account is required.</p>
+          <p class="text-muted-fg small">Enable JavaScript to see saved laws from this browser, or start building your collection from the archive.</p>
+        </header>
+        <div class="card-body text-center">
+          <div class="not-found-actions">
+            <a href="/browse" class="btn">
+              <span class="btn-text">Browse All Laws</span>
+            </a>
+            <a href="/categories" class="btn outline">
+              <span class="btn-text">Explore Categories</span>
+            </a>
+          </div>
+        </div>
+      </article>
+    </div>`;
+}
+
+function buildStaticSubmitContent(): string {
+  return `
+    <div class="container page">
+      <h1 class="page-title mb-4" data-page-title="Submit a Murphy's Law"><span class="accent-text">Submit</span> a Murphy's Law</h1>
+      <article class="card content-card">
+        <header class="card-header content-header">
+          <h2 class="card-title"><span class="accent-text">Share</span> a Law With the Archive</h2>
+          <p class="lead">Every submission is reviewed by a human before publication so the archive stays useful, readable, and trustworthy.</p>
+        </header>
+        <div class="card-body">
+          <section class="content-section">
+            <h3>What makes a good law?</h3>
+            <ul>
+              <li>Keep it short enough to quote.</li>
+              <li>Make the pattern specific, not just generally unlucky.</li>
+              <li>Include attribution when you know the original author or source.</li>
+              <li>Check the archive first so near-duplicates do not crowd out better versions.</li>
+            </ul>
+          </section>
+          <section class="content-section">
+            <h3>Submission expectations</h3>
+            <p>You may submit anonymously. If you include a name or source note, we use it only for attribution and moderation context.</p>
+            <p>If the form is unavailable, contact the archive directly at <a href="/contact">Contact</a>.</p>
+          </section>
+        </div>
+      </article>
+    </div>`;
+}
+
+function buildStaticHomeContent(): string {
+  return `
+    <div class="container page pt-0">
+      <section class="section section-card mb-12" data-home-zone="archive-search">
+        <div class="section-header">
+          <h1 class="section-title" data-section-title="Search the Archive"><span class="accent-text">Search</span> the Archive</h1>
+        </div>
+        <div class="section-subheader">
+          <p class="section-subtitle">Explore Murphy's Law history, browse thousands of laws, and find the category that fits your next mishap.</p>
+        </div>
+        <div class="section-body">
+          <div class="home-proof-points">
+            <span>2,400+ laws</span>
+            <span>55+ categories</span>
+            <span>Human-reviewed submissions</span>
+            <span>Curated since the late 1990s</span>
+          </div>
+          <div class="not-found-actions">
+            <a href="/browse" class="btn">Browse All Laws</a>
+            <a href="/categories" class="btn outline">Explore Categories</a>
+          </div>
+        </div>
+      </section>
+      <section class="section section-card mb-12" data-home-zone="law-of-day">
+        <div class="section-header">
+          <h2 class="section-title"><span class="accent-text">Law</span> of the Day</h2>
+        </div>
+        <div class="section-body">
+          <p>Enable JavaScript for today's rotating law, or browse the full archive now.</p>
+        </div>
+      </section>
+      <section class="section section-card mb-12" data-home-zone="category-discovery">
+        <div class="section-header">
+          <h2 class="section-title"><span class="accent-text">Browse</span> by Theme</h2>
+        </div>
+        <div class="section-body">
+          <p>Start with technology, work, travel, relationships, and everyday life categories.</p>
+          <a href="/categories" class="btn">See category groups</a>
+        </div>
+      </section>
+      <section class="section section-card mb-12" data-home-zone="tools-submit">
+        <div class="section-header">
+          <h2 class="section-title"><span class="accent-text">Tools</span> and Submissions</h2>
+        </div>
+        <div class="section-body">
+          <p>Try the calculators for playful risk modeling, then submit your own law for human review.</p>
+          <div class="not-found-actions">
+            <a href="/calculator/sods-law" class="btn">Try Sod's Law Calculator</a>
+            <a href="/calculator/buttered-toast" class="btn outline">Try Buttered Toast</a>
+            <a href="/submit" class="btn outline">Submit a Law</a>
+          </div>
+        </div>
+      </section>
+    </div>`;
+}
+
+function buildStaticCalculatorContent(kind: 'sods-law' | 'buttered-toast'): string {
+  if (kind === 'sods-law') {
+    return `
+      <div class="container page calculator">
+        <h1 class="page-title mb-4" data-page-title="Sod's Law Calculator"><span class="accent-text">Sod's</span> Law Calculator</h1>
+        <article class="card content-card">
+          <header class="card-header content-header">
+            <h2 class="card-title"><span class="accent-text">Estimate</span> Your Risk</h2>
+            <p class="lead">Model how likely a task is to go wrong using Urgency, Complexity, Importance, Skill, and Frequency.</p>
+          </header>
+          <div class="card-body">
+            <section class="content-section">
+              <h3>How the calculator works</h3>
+              <p>The interactive version lets you adjust each input and see the result change. Without JavaScript, this page still explains the assumptions behind the model.</p>
+              <ul>
+                <li><strong>Urgency:</strong> how much time pressure surrounds the task.</li>
+                <li><strong>Complexity:</strong> how many moving parts can fail.</li>
+                <li><strong>Importance:</strong> how painful failure would be.</li>
+                <li><strong>Skill:</strong> how much experience reduces risk.</li>
+                <li><strong>Frequency:</strong> how repeated attempts increase exposure.</li>
+              </ul>
+              <p class="small">This calculator is for entertainment and lightweight planning, not engineering risk certification.</p>
+            </section>
+          </div>
+        </article>
+      </div>`;
+  }
+
+  return `
+    <div class="container page calculator">
+      <h1 class="page-title mb-4" data-page-title="Buttered Toast Calculator"><span class="accent-text">Buttered</span> Toast Calculator</h1>
+      <article class="card content-card">
+        <header class="card-header content-header">
+          <h2 class="card-title"><span class="accent-text">Simulate</span> the Classic Mishap</h2>
+          <p class="lead">Explore why toast seems destined to land butter-side down when breakfast is already running late.</p>
+        </header>
+        <div class="card-body">
+          <section class="content-section">
+            <h3>Assumptions</h3>
+            <p>The simulator treats table height, rotation, butter coverage, and launch angle as playful inputs that influence the final landing side.</p>
+            <p>Enable JavaScript for the live controls, or read the explanation here to understand the joke behind the physics.</p>
+          </section>
+        </div>
+      </article>
+    </div>`;
 }
 
 async function main(): Promise<void> {
@@ -629,10 +883,10 @@ async function main(): Promise<void> {
   categoriesHtml = categoriesHtml.replace(/<link rel="canonical" href=".*?">/, `<link rel="canonical" href="https://murphys-laws.com/categories">`);
   categoriesHtml = updateHreflang(categoriesHtml, 'https://murphys-laws.com/categories');
 
-  // Build category cards HTML for SSG
-  const categoryCardsHtml = categories
-    .sort((a, b) => a.title.localeCompare(b.title))
-    .map(cat => {
+  // Build grouped category cards HTML for SSG
+  const categoryCardsHtml = groupCategories(categories)
+    .map(group => {
+      const cards = group.categories.map(cat => {
       const lawText = cat.law_count === 1 ? 'law' : 'laws';
       return `
       <article class="category-card" data-category-slug="${cat.slug}">
@@ -642,6 +896,17 @@ async function main(): Promise<void> {
           <span class="category-card-count">${cat.law_count} ${lawText}</span>
         </div>
       </article>`;
+      }).join('');
+      return `
+      <section class="category-cluster" data-category-cluster="${group.name}">
+        <header class="category-cluster-header">
+          <h2 class="category-cluster-title">${group.name}</h2>
+          <p class="category-cluster-description">${group.description}</p>
+        </header>
+        <div class="categories-grid">
+${cards.trim()}
+        </div>
+      </section>`;
     })
     .join('');
 
@@ -773,13 +1038,86 @@ ${cardHtml.trim()}
   }
   console.log(`Generated ${CONTENT_PAGES.length} content pages.`);
   
-  // 3b. Generate remaining static routes (calculator pages, submit) - SPA fallback only
-  const spaOnlyRoutes = ['calculator', 'toastcalculator', 'submit'];
-  
-  for (const route of spaOnlyRoutes) {
-    const routeDir = path.join(DIST_DIR, route);
+  // 3b. Generate app routes that hydrate on the client but still need useful static content
+  const staticAppRoutes = [
+    {
+      pathParts: ['calculator', 'sods-law'],
+      title: 'Sod\'s Law Calculator - Murphy\'s Law Archive',
+      description: 'Estimate how likely a task is to go wrong using urgency, complexity, importance, skill, and frequency.',
+      content: buildStaticCalculatorContent('sods-law'),
+      jsonLd: {
+        '@context': 'https://schema.org',
+        '@type': 'WebApplication',
+        'name': 'Sod\'s Law Calculator',
+        'url': `${SITE_URL}/calculator/sods-law`,
+        'description': 'Estimate how likely a task is to go wrong using urgency, complexity, importance, skill, and frequency.',
+        'applicationCategory': 'EntertainmentApplication'
+      }
+    },
+    {
+      pathParts: ['calculator', 'buttered-toast'],
+      title: 'Buttered Toast Calculator - Murphy\'s Law Archive',
+      description: 'A playful simulator for the classic Murphy\'s Law question: will toast land butter-side down?',
+      content: buildStaticCalculatorContent('buttered-toast'),
+      jsonLd: {
+        '@context': 'https://schema.org',
+        '@type': 'WebApplication',
+        'name': 'Buttered Toast Calculator',
+        'url': `${SITE_URL}/calculator/buttered-toast`,
+        'description': 'A playful simulator for the classic Murphy\'s Law question: will toast land butter-side down?',
+        'applicationCategory': 'EntertainmentApplication'
+      }
+    },
+    {
+      pathParts: ['submit'],
+      title: 'Submit a Murphy\'s Law - Murphy\'s Law Archive',
+      description: 'Submit a Murphy\'s Law for human review, with guidance on attribution, duplicate checks, and publication expectations.',
+      content: buildStaticSubmitContent(),
+      jsonLd: {
+        '@context': 'https://schema.org',
+        '@type': 'WebPage',
+        'name': 'Submit a Murphy\'s Law',
+        'url': `${SITE_URL}/submit`,
+        'description': 'Submit a Murphy\'s Law for human review.'
+      }
+    },
+    {
+      pathParts: ['favorites'],
+      title: 'My Favorites - Murphy\'s Law Archive',
+      description: 'Save favorite Murphy\'s Laws in your browser and revisit them quickly.',
+      content: buildStaticFavoritesContent(),
+      jsonLd: {
+        '@context': 'https://schema.org',
+        '@type': 'WebPage',
+        'name': 'My Favorites',
+        'url': `${SITE_URL}/favorites`,
+        'description': 'Save favorite Murphy\'s Laws in your browser and revisit them quickly.'
+      }
+    }
+  ];
+
+  for (const route of staticAppRoutes) {
+    const routePath = route.pathParts.join('/');
+    const routeDir = path.join(DIST_DIR, ...route.pathParts);
     await fs.mkdir(routeDir, { recursive: true });
-    await fs.copyFile(path.join(DIST_DIR, 'index.html'), path.join(routeDir, 'index.html'));
+
+    let routeHtml = template;
+    routeHtml = routeHtml.replace(/<title>.*?<\/title>/, `<title>${route.title}</title>`);
+    routeHtml = routeHtml.replace(
+      /<meta name="description" content=".*?">/,
+      `<meta name="description" content="${route.description}">`
+    );
+    routeHtml = routeHtml.replace(
+      /<link rel="canonical" href=".*?">/,
+      `<link rel="canonical" href="${SITE_URL}/${routePath}">`
+    );
+    routeHtml = updateHreflang(routeHtml, `${SITE_URL}/${routePath}`);
+    routeHtml = routeHtml.replace(
+      /<main[^>]*class="flex-1 container page"[^>]*>[\s\S]*?<\/main>/,
+      `<main id="main-content" class="flex-1 container page">${route.content}</main>`
+    );
+    routeHtml = injectJsonLd(routeHtml, generateJsonLd(route.jsonLd));
+    await fs.writeFile(path.join(routeDir, 'index.html'), routeHtml);
   }
 
   // 3c. Generate Law Detail Pages
@@ -809,7 +1147,7 @@ ${cardHtml.trim()}
   
   let homeHtml = template;
   
-  const homeContent = '';
+  const homeContent = buildStaticHomeContent();
 
   // Inject into main
   homeHtml = homeHtml.replace(
@@ -878,11 +1216,12 @@ ${cardHtml.trim()}
   </url>`;
   }
 
-  // Add SPA-only routes (calculators, submit)
-  for (const route of spaOnlyRoutes) {
+  // Add static app routes (calculators, submit, favorites)
+  for (const route of staticAppRoutes) {
+    const routePath = route.pathParts.join('/');
     sitemap += `
   <url>
-    <loc>${baseUrl}/${route}</loc>
+    <loc>${baseUrl}/${routePath}</loc>
     <lastmod>${today}</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
@@ -980,4 +1319,14 @@ if (isMainModule) {
 }
 
 // Export functions for testing
-export { wrapFirstWordWithAccent, enhanceMarkdownHtml, wrapInCardStructure };
+export {
+  CONTENT_PAGES,
+  wrapFirstWordWithAccent,
+  enhanceMarkdownHtml,
+  wrapInCardStructure,
+  buildStaticFavoritesContent,
+  buildStaticSubmitContent,
+  buildStaticHomeContent,
+  buildStaticCalculatorContent,
+  buildStaticLawDetailContent
+};

--- a/web/src/components/social-share.ts
+++ b/web/src/components/social-share.ts
@@ -8,6 +8,7 @@ import { createIcon } from '../utils/icons.ts';
 import { createButton, renderShareLinkHTML } from '../utils/button.ts';
 import { copyToClipboard } from '../utils/clipboard.ts';
 import { recordQualifyingUserAction } from './install-prompt.ts';
+import { trackProductEvent } from '@utils/metrics.ts';
 
 interface BuildShareUrlsOptions {
   url?: string;
@@ -533,6 +534,7 @@ export function initInlineShareButtons(container: HTMLElement, { getShareableUrl
     /* v8 ignore stop */
 
     recordQualifyingUserAction();
+    trackProductEvent('law.share', { surface: 'inline_share', action: action || 'copy' });
     if (action === 'copy-link') {
       await copyToClipboard(textToCopy, 'Link copied to clipboard!');
     } else {
@@ -547,6 +549,8 @@ export function initInlineShareButtons(container: HTMLElement, { getShareableUrl
     // Update URLs before navigation for share links
     if (target.closest('[data-share]')) {
       updateShareLinks();
+      const platform = target.closest('[data-share]')?.getAttribute('data-share') || 'social';
+      trackProductEvent('law.share', { surface: 'inline_share', action: platform });
       return; // Let the link navigate
     }
     // Handle copy buttons
@@ -571,7 +575,6 @@ export function initInlineShareButtons(container: HTMLElement, { getShareableUrl
 let globalListenersInitialized = false;
 /* v8 ignore start -- globalListenersInitialized prevents duplicate init on re-import; not testable without module reset */
 if (typeof document !== 'undefined' && !globalListenersInitialized) {
-  // eslint-disable-next-line no-useless-assignment -- flag is read on next top-level check
   globalListenersInitialized = true;
 
   document.addEventListener('click', () => {

--- a/web/src/components/submit-law.ts
+++ b/web/src/components/submit-law.ts
@@ -7,6 +7,7 @@ import { fetchAPI } from '../utils/api.ts';
 import { apiPost } from '../utils/request.ts';
 import { hydrateIcons } from '@utils/icons.ts';
 import { stripMarkdownFootnotes } from '../utils/sanitize.ts';
+import { trackProductEvent } from '@utils/metrics.ts';
 import {
   getCachedCategories,
   setCachedCategories,
@@ -185,6 +186,7 @@ export function SubmitLawSection() {
   // Template always has .submit-form
   form!.addEventListener('submit', async (e) => {
     e.preventDefault();
+    trackProductEvent('submit.start', { surface: 'submit_form' });
 
     const title = (el.querySelector('#submit-title') as HTMLInputElement | null)?.value.trim();
     const text = (el.querySelector('#submit-text') as HTMLTextAreaElement | null)?.value.trim();
@@ -226,6 +228,7 @@ export function SubmitLawSection() {
 
     try {
       await submitLaw(lawData);
+      trackProductEvent('submit.complete', { surface: 'submit_form', result: 'success' });
 
       showMessage(
         'Thank you! Your law has been submitted. We review submissions within a few days. Accepted laws appear in the archive. You cannot edit after submission.',

--- a/web/src/modules/structured-data.ts
+++ b/web/src/modules/structured-data.ts
@@ -123,13 +123,13 @@ export function setHomeStructuredData(): void {
         '@type': 'WebApplication',
         'name': "Sod's Law Calculator",
         'applicationCategory': 'CalculatorApplication',
-        'url': `${SITE_URL}/calculator`
+        'url': `${SITE_URL}/calculator/sods-law`
       },
       {
         '@type': 'WebApplication',
         'name': 'Buttered Toast Landing Calculator',
         'applicationCategory': 'CalculatorApplication',
-        'url': `${SITE_URL}/toastcalculator`
+        'url': `${SITE_URL}/calculator/buttered-toast`
       }
     ]
   });

--- a/web/src/types/ssg.d.ts
+++ b/web/src/types/ssg.d.ts
@@ -1,5 +1,34 @@
 declare module '@scripts/ssg' {
+  export interface ContentPageMeta {
+    slug: string;
+    file: string;
+    title: string;
+    description: string;
+  }
+
+  export interface StaticLaw {
+    id: number;
+    title?: string;
+    text?: string;
+    attributions?: { name?: string; contact_type?: string; contact_value?: string; note?: string }[];
+    attribution?: string;
+    author?: string;
+    category_slug?: string;
+    category_name?: string;
+    category_context?: string | null;
+    upvotes?: number;
+    downvotes?: number;
+    created_at?: string;
+    updated_at?: string;
+  }
+
+  export const CONTENT_PAGES: ContentPageMeta[];
   export function wrapFirstWordWithAccent(text: string): string;
   export function enhanceMarkdownHtml(html: string): string;
   export function wrapInCardStructure(html: string, options?: { lastUpdated?: string }): string;
+  export function buildStaticFavoritesContent(): string;
+  export function buildStaticSubmitContent(): string;
+  export function buildStaticCalculatorContent(kind: 'sods-law' | 'buttered-toast'): string;
+  export function buildStaticLawDetailContent(law: StaticLaw): string;
+  export function buildStaticHomeContent(): string;
 }

--- a/web/src/utils/category-groups.ts
+++ b/web/src/utils/category-groups.ts
@@ -1,0 +1,73 @@
+export interface GroupableCategory {
+  slug: string;
+  title: string;
+  law_count?: number;
+}
+
+export interface CategoryGroup<T extends GroupableCategory> {
+  name: string;
+  description: string;
+  categories: T[];
+}
+
+const GROUP_DEFINITIONS: { name: string; description: string; keywords: string[] }[] = [
+  {
+    name: 'Technology',
+    description: 'Computers, software, engineering, printing, photography, and technical systems.',
+    keywords: ['computer', 'technology', 'software', 'printing', 'photography', 'microbiology', 'graphic-design']
+  },
+  {
+    name: 'Work',
+    description: 'Office, teaching, commerce, healthcare, project, and professional life.',
+    keywords: ['office', 'employees', 'teaching', 'commerce', 'nurses', 'emt', 'repairmen', 'mechanics']
+  },
+  {
+    name: 'Transport',
+    description: 'Cars, buses, travel, aviation, ships, elevators, and anything that moves.',
+    keywords: ['cars', 'bus', 'travel', 'airplanes', 'helicopters', 'marine', 'elevator', 'tanks']
+  },
+  {
+    name: 'Relationships',
+    description: 'Love, family, mothers, toddlers, and social life.',
+    keywords: ['love', 'mothers', 'toddlers']
+  },
+  {
+    name: 'Everyday Life',
+    description: 'Home, hobbies, sport, alarms, lotto, and ordinary trouble.',
+    keywords: ['alarm', 'sport', 'golf', 'music', 'sewing', 'lotto', 'rental', 'real-estate', 'horse']
+  },
+  {
+    name: 'Historical and Military',
+    description: 'Military, war, scouting, police, and field operations.',
+    keywords: ['war', 'military', 'desert', 'fighting', 'police', 'scouting', 'bushfire']
+  },
+  {
+    name: 'Specialized',
+    description: 'Games, fandoms, niche hobbies, and specialist collections.',
+    keywords: ['role-playing', 'game', 'transformers', 'jagged', 'cowboy', 'martial']
+  }
+];
+
+function getGroupName(slug: string): string {
+  const normalizedSlug = slug.toLowerCase();
+  const definition = GROUP_DEFINITIONS.find((group) => group.keywords.some((keyword) => normalizedSlug.includes(keyword)));
+  return definition?.name ?? 'Specialized';
+}
+
+export function groupCategories<T extends GroupableCategory>(categories: T[]): CategoryGroup<T>[] {
+  const byName = new Map<string, T[]>();
+  categories.forEach((category) => {
+    const groupName = getGroupName(category.slug);
+    const groupCategories = byName.get(groupName) ?? [];
+    groupCategories.push(category);
+    byName.set(groupName, groupCategories);
+  });
+
+  return GROUP_DEFINITIONS
+    .filter((definition) => byName.has(definition.name))
+    .map((definition) => ({
+      name: definition.name,
+      description: definition.description,
+      categories: [...byName.get(definition.name)!].sort((a, b) => a.title.localeCompare(b.title))
+    }));
+}

--- a/web/src/utils/metrics.ts
+++ b/web/src/utils/metrics.ts
@@ -14,12 +14,35 @@ function hasMetrics(): boolean {
   return metricsEnabled && typeof Sentry.metrics?.count === 'function';
 }
 
+export type ProductEventName =
+  | 'archive.search'
+  | 'archive.no_results'
+  | 'category.click'
+  | 'law.related_click'
+  | 'law.vote'
+  | 'law.favorite'
+  | 'law.share'
+  | 'calculator.start'
+  | 'calculator.complete'
+  | 'submit.start'
+  | 'submit.complete';
+
+type ProductEventTags = Partial<Record<'surface' | 'result' | 'category' | 'action' | 'calculator', string>>;
+
 /**
  * Increment a counter (e.g. button clicks, API calls).
  */
-export function count(name: string, value: number = 1): void {
+export function count(name: string, value: number = 1, options?: { tags?: Record<string, string>; unit?: string }): void {
   if (!hasMetrics()) return;
+  if (options) {
+    Sentry.metrics.count(name, value, options);
+    return;
+  }
   Sentry.metrics.count(name, value);
+}
+
+export function trackProductEvent(name: ProductEventName, tags: ProductEventTags = {}): void {
+  count(`product.${name}`, 1, { tags });
 }
 
 /**

--- a/web/src/views/buttered-toast-calculator.ts
+++ b/web/src/views/buttered-toast-calculator.ts
@@ -7,6 +7,7 @@ import { hydrateIcons } from '@utils/icons.ts';
 import { updateMetaDescription } from '@utils/dom.ts';
 import { setExportContent, clearExportContent, ContentType } from '@utils/export-context.ts';
 import { renderInlineShareButtonsHTML, initInlineShareButtons } from '@components/social-share.ts';
+import { trackProductEvent } from '@utils/metrics.ts';
 import type { CleanableElement } from '../types/app.d.ts';
 
 type ToastSliderKey = 'height' | 'gravity' | 'overhang' | 'butter' | 'friction' | 'inertia';
@@ -14,6 +15,7 @@ type ToastSliderKey = 'height' | 'gravity' | 'overhang' | 'butter' | 'friction' 
 export function ButteredToastCalculator(): HTMLDivElement {
   const el = document.createElement('div');
   el.className = 'container page calculator';
+  let hasTrackedStart = false;
 
   el.innerHTML = templateHtml;
 
@@ -229,6 +231,10 @@ export function ButteredToastCalculator(): HTMLDivElement {
 
   (Object.keys(sliders) as ToastSliderKey[]).forEach((k) => {
     sliders[k]?.addEventListener('input', () => {
+      if (!hasTrackedStart) {
+        hasTrackedStart = true;
+        trackProductEvent('calculator.start', { surface: 'calculator_page', calculator: 'buttered-toast' });
+      }
       const val = sliders[k].value;
 
       // Update ARIA attributes
@@ -244,6 +250,7 @@ export function ButteredToastCalculator(): HTMLDivElement {
 
       flashAllVariables();
       calculateLanding();
+      trackProductEvent('calculator.complete', { surface: 'calculator_page', calculator: 'buttered-toast' });
     });
   });
 

--- a/web/src/views/categories.ts
+++ b/web/src/views/categories.ts
@@ -6,6 +6,8 @@ import { fetchCategories } from '../utils/api.ts';
 import { hydrateIcons } from '@utils/icons.ts';
 import { getRandomLoadingMessage, getCategoryDisplayName } from '../utils/constants.ts';
 import { stripMarkdownFootnotes } from '../utils/sanitize.ts';
+import { groupCategories } from '@utils/category-groups.ts';
+import { trackProductEvent } from '@utils/metrics.ts';
 import { setExportContent, clearExportContent, ContentType } from '../utils/export-context.ts';
 import { updateMetaDescription } from '@utils/dom.ts';
 import type { CleanableElement, OnNavigate, Category } from '../types/app.d.ts';
@@ -53,12 +55,19 @@ export function Categories({ onNavigate }: { onNavigate: OnNavigate }): HTMLDivE
       `;
     }
 
-    // Sort categories alphabetically by title
-    const sortedCategories = [...categories].sort((a, b) => 
-      a.title.localeCompare(b.title)
-    );
-
-    return sortedCategories.map(renderCategoryCard).join('');
+    return groupCategories(categories)
+      .map((group) => `
+        <section class="category-cluster" data-category-cluster="${group.name}">
+          <header class="category-cluster-header">
+            <h2 class="category-cluster-title">${group.name}</h2>
+            <p class="category-cluster-description">${group.description}</p>
+          </header>
+          <div class="categories-grid">
+            ${group.categories.map(renderCategoryCard).join('')}
+          </div>
+        </section>
+      `)
+      .join('');
   }
 
   // Render the page structure
@@ -132,7 +141,10 @@ export function Categories({ onNavigate }: { onNavigate: OnNavigate }): HTMLDivE
     const card = target.closest('.category-card');
     if (card) {
       const slug = card.getAttribute('data-category-slug');
-      if (slug) onNavigate('category', slug);
+      if (slug) {
+        trackProductEvent('category.click', { surface: 'categories', category: slug });
+        onNavigate('category', slug);
+      }
       return;
     }
 

--- a/web/src/views/home.ts
+++ b/web/src/views/home.ts
@@ -3,28 +3,73 @@
 import { LawOfTheDay } from '@components/law-of-day.ts';
 import { SodCalculatorSimple } from '@components/sod-calculator-simple.ts';
 import { ButteredToastCalculatorSimple } from '@components/buttered-toast-calculator-simple.ts';
-import { SubmitLawSection } from '@components/submit-law.ts';
 import { fetchLawOfTheDay } from '../utils/api.ts';
 import { createErrorState } from '../utils/dom.ts';
 import { renderLoadingHTML } from '../components/loading.ts';
 import { triggerAdSense } from '../utils/ads.ts';
 import { setExportContent, clearExportContent, ContentType } from '../utils/export-context.ts';
 import { hydrateIcons } from '@utils/icons.ts';
+import { trackProductEvent } from '@utils/metrics.ts';
 import type { CleanableElement, OnNavigate, Law } from '../types/app.d.ts';
 
-const BROWSE_CTA_HTML = `
-  <section class="section section-card mb-12 browse-cta" aria-labelledby="browse-cta-heading">
+const ARCHIVE_SEARCH_HTML = `
+  <section class="section section-card mb-12 browse-cta" data-home-zone="archive-search" aria-labelledby="browse-cta-heading">
     <div class="section-header">
-      <h2 id="browse-cta-heading" class="section-title"><span class="accent-text">Browse</span> the Archive</h2>
+      <h1 id="browse-cta-heading" class="section-title"><span class="accent-text">Search</span> the Archive</h1>
     </div>
     <div class="section-subheader">
-      <p class="section-subtitle">Search and filter the complete collection of Murphy's Laws by category, theme, or keyword.</p>
+      <p class="section-subtitle">Start with the complete Murphy's Law archive, then save, vote, share, or submit the next inevitable discovery.</p>
     </div>
     <div class="section-body">
+      <form role="search" class="not-found-search-form" aria-label="Search the archive" data-nav="browse">
+        <input type="search" class="form-control" placeholder="Search laws, categories, and mishaps" aria-label="Search laws">
+        <button type="submit" class="btn primary">
+          <span class="btn-text">Search the Archive</span>
+          <span class="icon" data-icon="search" aria-hidden="true"></span>
+        </button>
+      </form>
+      <div class="home-proof-points">
+        <span>2,400+ laws</span>
+        <span>55+ categories</span>
+        <span>Human-reviewed submissions</span>
+        <span>Curated since the late 1990s</span>
+      </div>
       <a href="/browse" class="btn primary" data-nav="browse">
         <span class="btn-text">Browse All Laws</span>
         <span class="icon" data-icon="list" aria-hidden="true"></span>
       </a>
+    </div>
+  </section>
+`;
+
+const CATEGORY_DISCOVERY_HTML = `
+  <section class="section section-card mb-12" data-home-zone="category-discovery" aria-labelledby="category-discovery-heading">
+    <div class="section-header">
+      <h2 id="category-discovery-heading" class="section-title"><span class="accent-text">Browse</span> by Theme</h2>
+    </div>
+    <div class="section-subheader">
+      <p class="section-subtitle">Jump into grouped categories for technology, work, travel, relationships, and everyday trouble.</p>
+    </div>
+    <div class="section-body">
+      <div class="not-found-actions">
+        <a href="/categories" class="btn" data-nav="categories">Explore Categories</a>
+        <a href="/category/murphys-technology-laws" class="btn outline" data-nav="category:murphys-technology-laws">Technology Laws</a>
+        <a href="/category/murphys-office-laws" class="btn outline" data-nav="category:murphys-office-laws">Work Laws</a>
+      </div>
+    </div>
+  </section>
+`;
+
+const SUBMIT_CTA_HTML = `
+  <section class="section section-card mb-12" aria-labelledby="submit-cta-heading">
+    <div class="section-header">
+      <h2 id="submit-cta-heading" class="section-title"><span class="accent-text">Submit</span> Your Own</h2>
+    </div>
+    <div class="section-subheader">
+      <p class="section-subtitle">Contributions are human-reviewed before publication. Send the sharp version, include attribution if you know it, and check for duplicates first.</p>
+    </div>
+    <div class="section-body">
+      <a href="/submit" class="btn" data-nav="submit">Submit a Law</a>
     </div>
   </section>
 `;
@@ -83,29 +128,50 @@ const HOME_OVERVIEW_HTML = `
 export function renderHome(el: HTMLElement, lawOfTheDay: Law | null, _categories: unknown, onNavigate: OnNavigate): void {
   el.innerHTML = '';
 
-  if (lawOfTheDay) {
-    const widget = LawOfTheDay({ law: lawOfTheDay, onNavigate });
-    el.appendChild(widget);
-  }
-
-  // Elevated Browse CTA
+  // Primary discovery zone
   const browseWrap = document.createElement('div');
-  browseWrap.innerHTML = BROWSE_CTA_HTML;
+  browseWrap.innerHTML = ARCHIVE_SEARCH_HTML;
   const browseCta = browseWrap.firstElementChild!;
   hydrateIcons(browseCta as HTMLElement);
   el.appendChild(browseCta);
+  const searchForm = browseCta.querySelector('form[role="search"]');
+  if (searchForm instanceof HTMLFormElement) {
+    searchForm.addEventListener('submit', (e) => {
+      e.preventDefault();
+      trackProductEvent('archive.search', { surface: 'home', result: 'submitted' });
+      onNavigate('browse');
+    });
+  }
 
-  // Add Sod's Law Calculator widget
+  if (lawOfTheDay) {
+    const lawZone = document.createElement('section');
+    lawZone.setAttribute('data-home-zone', 'law-of-day');
+    const widget = LawOfTheDay({ law: lawOfTheDay, onNavigate });
+    lawZone.appendChild(widget);
+    el.appendChild(lawZone);
+  }
+
+  const categoryWrap = document.createElement('div');
+  categoryWrap.innerHTML = CATEGORY_DISCOVERY_HTML;
+  const categorySection = categoryWrap.firstElementChild!;
+  hydrateIcons(categorySection as HTMLElement);
+  el.appendChild(categorySection);
+
+  const toolsZone = document.createElement('section');
+  toolsZone.setAttribute('data-home-zone', 'tools-submit');
+
   const calcWidget = SodCalculatorSimple({ onNavigate });
-  el.appendChild(calcWidget);
+  toolsZone.appendChild(calcWidget);
 
-  // Add Buttered Toast Calculator widget
   const toastWidget = ButteredToastCalculatorSimple({ onNavigate });
-  el.appendChild(toastWidget);
+  toolsZone.appendChild(toastWidget);
 
-  // Add Submit Law section
-  const submitWidget = SubmitLawSection();
-  el.appendChild(submitWidget);
+  const submitWrap = document.createElement('div');
+  submitWrap.innerHTML = SUBMIT_CTA_HTML;
+  const submitCta = submitWrap.firstElementChild!;
+  toolsZone.appendChild(submitCta);
+  hydrateIcons(toolsZone);
+  el.appendChild(toolsZone);
 
   // Add Science of Murphy's Law section (below Submit a Law)
   const scienceWrap = document.createElement('div');
@@ -172,8 +238,11 @@ export function Home({ onNavigate }: { onNavigate: OnNavigate }): HTMLDivElement
       if (navTarget) {
         if (navTarget.startsWith('category:')) {
           const catId = navTarget.split(':')[1];
+          trackProductEvent('category.click', { surface: 'home', category: catId });
           onNavigate('category', catId);
         } else {
+          if (navTarget === 'browse') trackProductEvent('archive.search', { surface: 'home', result: 'browse' });
+          if (navTarget === 'submit') trackProductEvent('submit.start', { surface: 'home' });
           onNavigate(navTarget);
         }
         return;

--- a/web/src/views/law-detail.ts
+++ b/web/src/views/law-detail.ts
@@ -18,6 +18,7 @@ import { isFavorite, toggleFavorite } from '../utils/favorites.ts';
 import { setExportContent, clearExportContent, ContentType } from '../utils/export-context.ts';
 import { Breadcrumb } from '../components/breadcrumb.ts';
 import { getDefaultLawContext } from '../utils/law-context-copy.ts';
+import { trackProductEvent } from '@utils/metrics.ts';
 import type { CleanableElement, Law } from '../types/app.ts';
 
 interface LawDetailProps {
@@ -306,6 +307,14 @@ export function LawDetail({ lawId, onNavigate, onStructuredData }: LawDetailProp
       contextTextEl.textContent = contextText;
     }
 
+    const sourceStatusEl = el.querySelector('[data-law-source-status]');
+    if (sourceStatusEl) {
+      const attributionName = law.attributions?.[0]?.name || law.author || law.attribution || '';
+      sourceStatusEl.textContent = attributionName
+        ? `Attributed to ${attributionName}`
+        : 'Source not yet verified by the archive.';
+    }
+
     // Fetch and render related laws
     loadRelatedLaws(law.id);
   }
@@ -444,6 +453,7 @@ export function LawDetail({ lawId, onNavigate, onStructuredData }: LawDetailProp
         text: lawText,
         title: lawTitle,
       });
+      trackProductEvent('law.favorite', { surface: 'law_detail', action: isNowFavorite ? 'add' : 'remove' });
 
       // Update button visual state
       /* v8 ignore start -- both tooltip states tested; icon always present in hydrated button */
@@ -486,6 +496,7 @@ export function LawDetail({ lawId, onNavigate, onStructuredData }: LawDetailProp
         text: lawText,
         title: lawTitle,
       });
+      trackProductEvent('law.favorite', { surface: 'related_laws', action: isNowFavorite ? 'add' : 'remove' });
 
       // Update button visual state
       /* v8 ignore start -- both tooltip states tested; icon always present in hydrated button */
@@ -511,6 +522,7 @@ export function LawDetail({ lawId, onNavigate, onStructuredData }: LawDetailProp
     if (lawCard && lawCard.dataset.lawId) {
       // Don't navigate if clicking on interactive elements (buttons for voting, favorites, share)
       if (t.closest('button')) return;
+      trackProductEvent('law.related_click', { surface: 'law_detail' });
       onNavigate('law', lawCard.dataset.lawId);
       return;
     }
@@ -537,6 +549,7 @@ export function LawDetail({ lawId, onNavigate, onStructuredData }: LawDetailProp
 
       try {
         const result = await toggleVote(lawId, voteType);
+        trackProductEvent('law.vote', { surface: 'law_detail', action: voteType });
 
         // Update vote counts in UI
         const upVoteCount = el.querySelector('[data-upvote-count]');

--- a/web/src/views/sods-calculator.ts
+++ b/web/src/views/sods-calculator.ts
@@ -9,6 +9,7 @@ import { hydrateIcons } from '@utils/icons.ts';
 import { updateMetaDescription } from '@utils/dom.ts';
 import { setExportContent, clearExportContent, ContentType } from '@utils/export-context.ts';
 import { renderInlineShareButtonsHTML, initInlineShareButtons } from '@components/social-share.ts';
+import { trackProductEvent } from '@utils/metrics.ts';
 import type { CleanableElement } from '../types/app.d.ts';
 
 type SliderKey = 'urgency' | 'complexity' | 'importance' | 'skill' | 'frequency';
@@ -70,6 +71,7 @@ export function Calculator(): HTMLDivElement {
   type FormulaVarKey = 'U' | 'C' | 'I' | 'S' | 'F';
   const showValues: Record<FormulaVarKey, boolean> = { U: false, C: false, I: false, S: false, F: false };
   let resetTimeouts: Record<FormulaVarKey, ReturnType<typeof setTimeout> | null> = { U: null, C: null, I: null, S: null, F: null };
+  let hasTrackedStart = false;
 
   function updateCalculation() {
     const U = parseFloat(sliders.urgency.value);
@@ -189,6 +191,10 @@ export function Calculator(): HTMLDivElement {
 
   (Object.keys(sliders) as SliderKey[]).forEach((k) => {
     sliders[k].addEventListener('input', () => {
+      if (!hasTrackedStart) {
+        hasTrackedStart = true;
+        trackProductEvent('calculator.start', { surface: 'calculator_page', calculator: 'sods-law' });
+      }
       const val = sliders[k].value;
       sliderValues[k].textContent = val;
 
@@ -197,6 +203,7 @@ export function Calculator(): HTMLDivElement {
       sliders[k].setAttribute('aria-valuetext', val);
 
       flashAllVariables();
+      trackProductEvent('calculator.complete', { surface: 'calculator_page', calculator: 'sods-law' });
     });
   });
 

--- a/web/src/views/templates/favorites.html
+++ b/web/src/views/templates/favorites.html
@@ -1,3 +1,23 @@
-<div id="favorites-root" class="loading-placeholder" role="status" aria-label="Loading favorites">
-  <p class="text-center small">Loading favorites...</p>
+<div id="favorites-root">
+  <h1 class="page-title mb-4" data-page-title="My Favorites"><span class="accent-text">My</span> Favorites</h1>
+  <div class="card content-card">
+    <header class="card-header text-center">
+      <h2 class="card-title"><span class="accent-text">No Favorites</span> Yet</h2>
+      <blockquote class="not-found-quote">
+        "The law you need most will be the one you forgot to save."
+      </blockquote>
+      <p class="text-muted-fg">Your favorites collection is empty. Save laws to access them quickly.</p>
+      <p class="text-muted-fg small">Favorites are stored in your browser only; no account is required.</p>
+    </header>
+    <div class="card-body text-center">
+      <div class="not-found-actions">
+        <a href="/browse" class="btn">
+          <span class="btn-text">Browse All Laws</span>
+        </a>
+        <a href="/categories" class="btn outline">
+          <span class="btn-text">Explore Categories</span>
+        </a>
+      </div>
+    </div>
+  </div>
 </div>

--- a/web/src/views/templates/law-detail.html
+++ b/web/src/views/templates/law-detail.html
@@ -16,6 +16,15 @@
       </div>
     </div>
   </section>
+  <section class="section section-card mb-12" data-law-provenance aria-labelledby="law-provenance-heading">
+    <div class="section-header">
+      <h3 id="law-provenance-heading" class="section-title"><span class="accent-text">Source</span> status</h3>
+    </div>
+    <div class="section-body">
+      <p data-law-source-status>Source not yet verified by the archive.</p>
+      <p class="small">Know the original source, a better attribution, or a duplicate we should merge? <a href="/contact" data-law-report-link>Report an issue</a>.</p>
+    </div>
+  </section>
   <section class="section section-card related-laws-section" data-related-laws hidden>
     <div class="section-header">
       <h3 class="section-title"><span class="accent-text">Related</span> Laws</h3>

--- a/web/src/views/templates/submit-law-section.html
+++ b/web/src/views/templates/submit-law-section.html
@@ -4,6 +4,14 @@
 <div class="section-subheader">
   <p class="section-subtitle">Share your own Murphy's Law discovery</p>
 </div>
+<div class="section-body submit-guidance">
+  <p>Every submission is reviewed by a human before publication.</p>
+  <ul>
+    <li>Keep it short, memorable, and specific.</li>
+    <li>Include attribution when you know the original author or source.</li>
+    <li>Search first so duplicates do not crowd out sharper versions.</li>
+  </ul>
+</div>
 <form class="section-body submit-form form">
   <div class="form-group">
     <label for="submit-title" class="form-label">Law Title</label>

--- a/web/tests/categories.test.ts
+++ b/web/tests/categories.test.ts
@@ -92,6 +92,15 @@ describe('Categories view', () => {
     expect(el.textContent).toContain('Romance rules: the heart wants what it cannot have.');
   });
 
+  it('groups categories into editorial superclusters', async () => {
+    const el = Categories({ onNavigate: localThis.onNavigate });
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    expect(el.querySelector('[data-category-cluster="Technology"]')).toBeTruthy();
+    expect(el.querySelector('[data-category-cluster="Everyday Life"]')).toBeTruthy();
+    expect(el.querySelector('[data-category-cluster="Relationships"]')).toBeTruthy();
+  });
+
   it('displays fallback description when none provided', async () => {
     const el = Categories({ onNavigate: localThis.onNavigate });
     await new Promise(resolve => setTimeout(resolve, 10));
@@ -123,17 +132,15 @@ describe('Categories view', () => {
     expect(el.textContent).not.toContain('1 laws');
   });
 
-  it('sorts categories alphabetically by title', async () => {
+  it('sorts categories alphabetically within editorial groups', async () => {
     const el = Categories({ onNavigate: localThis.onNavigate });
     await new Promise(resolve => setTimeout(resolve, 10));
 
     const cards = el.querySelectorAll('.category-card');
     expect(cards.length).toBe(3);
-    
-    // Should be alphabetically sorted: Alarm Clock, Computer, Love
-    expect(cards[0]!.textContent).toContain("Murphy's Alarm Clock Laws");
-    expect(cards[1]!.textContent).toContain("Murphy's Computer Laws");
-    expect(cards[2]!.textContent).toContain("Murphy's Love Laws");
+    expect(el.querySelector('[data-category-cluster="Technology"]')?.textContent).toContain("Murphy's Computer Laws");
+    expect(el.querySelector('[data-category-cluster="Everyday Life"]')?.textContent).toContain("Murphy's Alarm Clock Laws");
+    expect(el.querySelector('[data-category-cluster="Relationships"]')?.textContent).toContain("Murphy's Love Laws");
   });
 
   it('L139 B1: click on category card triggers onNavigate with slug', async () => {

--- a/web/tests/category-groups.test.ts
+++ b/web/tests/category-groups.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { groupCategories } from '../src/utils/category-groups.ts';
+
+describe('category groups', () => {
+  it('returns no groups for an empty category list', () => {
+    expect(groupCategories([])).toEqual([]);
+  });
+
+  it('groups known category slugs into editorial clusters', () => {
+    const groups = groupCategories([
+      { slug: 'murphys-computer-laws', title: "Murphy's Computer Laws" },
+      { slug: 'murphys-office-laws', title: "Murphy's Office Laws" },
+      { slug: 'murphys-travel-laws', title: "Murphy's Travel Laws" },
+      { slug: 'murphys-love-laws', title: "Murphy's Love Laws" },
+      { slug: 'murphys-alarm-clock-laws', title: "Murphy's Alarm Clock Laws" },
+      { slug: 'murphys-war-laws', title: "Murphy's War Laws" },
+      { slug: 'murphys-game-mastering-laws', title: "Murphy's Game Mastering Laws" },
+    ]);
+
+    expect(groups.map((group) => group.name)).toEqual([
+      'Technology',
+      'Work',
+      'Transport',
+      'Relationships',
+      'Everyday Life',
+      'Historical and Military',
+      'Specialized',
+    ]);
+  });
+
+  it('sorts categories within groups and falls back to Specialized', () => {
+    const groups = groupCategories([
+      { slug: 'uncategorized-mishaps', title: 'Zebra Mishaps' },
+      { slug: 'another-uncategorized-mishaps', title: 'Alpha Mishaps' },
+    ]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.name).toBe('Specialized');
+    expect(groups[0]!.categories.map((category) => category.title)).toEqual([
+      'Alpha Mishaps',
+      'Zebra Mishaps',
+    ]);
+  });
+});

--- a/web/tests/developers.test.ts
+++ b/web/tests/developers.test.ts
@@ -39,4 +39,35 @@ describe('Developers page', () => {
     expect(typeof el.cleanup).toBe('function');
     el.cleanup!();
   });
+
+  it('ignores clicks without navigation targets', () => {
+    let navigated = false;
+    const el = Developers({ onNavigate: () => { navigated = true; } });
+    el.click();
+    expect(navigated).toBe(false);
+  });
+
+  it('navigates when a data-nav target is clicked', () => {
+    let target = '';
+    const el = Developers({ onNavigate: (next) => { target = next; } });
+    const button = document.createElement('button');
+    button.setAttribute('data-nav', 'browse');
+    el.appendChild(button);
+
+    button.click();
+
+    expect(target).toBe('browse');
+  });
+
+  it('ignores empty data-nav targets', () => {
+    let navigated = false;
+    const el = Developers({ onNavigate: () => { navigated = true; } });
+    const button = document.createElement('button');
+    button.setAttribute('data-nav', '');
+    el.appendChild(button);
+
+    button.click();
+
+    expect(navigated).toBe(false);
+  });
 });

--- a/web/tests/favorites-view.test.ts
+++ b/web/tests/favorites-view.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import type { OnNavigate, FavoriteLaw } from '../src/types/app.d.ts';
 import { Favorites } from '../src/views/favorites.js';
+import favoritesTemplateHtml from '../src/views/templates/favorites.html?raw';
 
 // Mock feature flags
 vi.mock('../src/utils/feature-flags.js', () => ({
@@ -47,6 +48,13 @@ describe('Favorites View Component', () => {
     mockLaw1: { id: 123, text: 'Test law text', title: 'Test Law', savedAt: 0 },
     mockLaw2: { id: 456, text: 'Another law text', title: 'Another Law', savedAt: 0 },
   };
+
+  it('ships a useful no-JS empty state in the template', () => {
+    expect(favoritesTemplateHtml).toContain('My Favorites');
+    expect(favoritesTemplateHtml).toContain('stored in your browser');
+    expect(favoritesTemplateHtml).toContain('/browse');
+    expect(favoritesTemplateHtml).not.toMatch(/Loading favorites/i);
+  });
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/web/tests/home.test.ts
+++ b/web/tests/home.test.ts
@@ -5,6 +5,31 @@ import { Home, renderHome } from '../src/views/home.ts';
 import * as exportContext from '../src/utils/export-context.js';
 
 describe('Home view', () => {
+  it('renders homepage zones around the discovery and contribution loops', () => {
+    const el = document.createElement('div');
+
+    renderHome(el, { id: 1, text: 'Test law', upvotes: 0, downvotes: 0 }, [], () => {});
+
+    expect(el.querySelector('[data-home-zone="archive-search"]')).toBeTruthy();
+    expect(el.querySelector('[data-home-zone="law-of-day"]')).toBeTruthy();
+    expect(el.querySelector('[data-home-zone="category-discovery"]')).toBeTruthy();
+    expect(el.querySelector('[data-home-zone="tools-submit"]')).toBeTruthy();
+    expect(el.textContent).toMatch(/human-reviewed/i);
+  });
+
+  it('routes homepage search submissions to browse', () => {
+    const el = document.createElement('div');
+    const onNavigate = vi.fn<OnNavigate>() as Mock<OnNavigate>;
+
+    renderHome(el, { id: 1, text: 'Test law', upvotes: 0, downvotes: 0 }, [], onNavigate);
+    const form = el.querySelector('form[role="search"]');
+    expect(form).toBeTruthy();
+
+    form!.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+
+    expect(onNavigate).toHaveBeenCalledWith('browse');
+  });
+
   it('renders Law of the Day after fetching data', async () => {
     const lawOfTheDay = {
       id: '1',

--- a/web/tests/law-detail.test.ts
+++ b/web/tests/law-detail.test.ts
@@ -57,6 +57,15 @@ describe('LawDetail view', () => {
     expect(el.querySelector('[data-upvote-count]')?.textContent).toBe('1');
   });
 
+  it('renders source status and report issue action for fetched law details', async () => {
+    const law = { id: '1', title: 'A Law', text: 'Text', score: 1, attributions: [{ name: 'Known Source' }] };
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => law });
+    const el = LawDetail({ lawId: '1', onNavigate: () => { } });
+
+    await vi.waitFor(() => expect(el.querySelector('[data-law-source-status]')?.textContent).toContain('Known Source'), { timeout: 500 });
+    expect(el.querySelector('[data-law-report-link]')?.getAttribute('href')).toBe('/contact');
+  });
+
   it('L207 B1: breadcrumbContainer exists so breadcrumb rendered', async () => {
     const law = { id: '1', title: 'T', text: 'T', score: 0 };
     globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => law });

--- a/web/tests/metrics.test.ts
+++ b/web/tests/metrics.test.ts
@@ -77,4 +77,17 @@ describe('metrics', () => {
     count('event');
     expect(mockCount).toHaveBeenCalledWith('event', 1);
   });
+
+  it('tracks typed product events with privacy-safe tags', async () => {
+    import.meta.env.VITE_SENTRY_DSN = 'https://key@o1.ingest.sentry.io/1';
+    import.meta.env.PROD = true;
+    vi.resetModules();
+
+    const { trackProductEvent } = await import('../src/utils/metrics.ts');
+    trackProductEvent('archive.search', { surface: 'home', result: 'submitted' });
+
+    expect(mockCount).toHaveBeenCalledWith('product.archive.search', 1, {
+      tags: { surface: 'home', result: 'submitted' }
+    });
+  });
 });

--- a/web/tests/ssg.test.ts
+++ b/web/tests/ssg.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect } from 'vitest';
-import { wrapFirstWordWithAccent, enhanceMarkdownHtml, wrapInCardStructure } from '@scripts/ssg';
+import {
+  wrapFirstWordWithAccent,
+  enhanceMarkdownHtml,
+  wrapInCardStructure,
+  CONTENT_PAGES,
+  buildStaticFavoritesContent,
+  buildStaticSubmitContent,
+  buildStaticCalculatorContent,
+  buildStaticLawDetailContent,
+  buildStaticHomeContent
+} from '@scripts/ssg';
 
 describe('SSG Utilities', () => {
   describe('wrapFirstWordWithAccent', () => {
@@ -143,5 +153,73 @@ describe('SSG Utilities', () => {
       expect(result).toContain('<div class="card-body">');
       expect(result).toContain('content-section');
     });
+  });
+});
+
+describe('SSG Static Route Content', () => {
+  it('includes developers as a generated content page', () => {
+    expect(CONTENT_PAGES.map((page) => page.slug)).toContain('developers');
+  });
+
+  it('renders a useful static favorites empty state', () => {
+    const html = buildStaticFavoritesContent();
+
+    expect(html).toContain('My Favorites');
+    expect(html).toContain('stored in your browser');
+    expect(html).toContain('/browse');
+    expect(html).not.toMatch(/Loading favorites/i);
+  });
+
+  it('renders static submit guidance with moderation and attribution copy', () => {
+    const html = buildStaticSubmitContent();
+
+    expect(html).toContain("Submit a Murphy's Law");
+    expect(html).toMatch(/reviewed by a human/i);
+    expect(html).toMatch(/attribution/i);
+    expect(html).toContain('/contact');
+    expect(html).not.toMatch(/Loading the archive/i);
+  });
+
+  it('renders static calculator explainer content for Sod and toast calculators', () => {
+    const sod = buildStaticCalculatorContent('sods-law');
+    const toast = buildStaticCalculatorContent('buttered-toast');
+
+    expect(sod).toContain("Sod's Law Calculator");
+    expect(sod).toMatch(/Urgency/i);
+    expect(sod).toMatch(/for entertainment/i);
+    expect(toast).toContain('Buttered Toast');
+    expect(toast).toMatch(/assumptions/i);
+    expect(toast).toMatch(/simulator/i);
+  });
+
+  it('renders law detail pages as destination pages', () => {
+    const html = buildStaticLawDetailContent({
+      id: 42,
+      title: 'Test Law',
+      text: 'Anything tested can fail.',
+      category_slug: 'murphys-technology-laws',
+      category_name: "Murphy's Technology Laws",
+      attributions: [{ name: 'QA Engineer' }],
+      upvotes: 7,
+      downvotes: 2
+    });
+
+    expect(html).toContain('Anything tested can fail.');
+    expect(html).toContain('QA Engineer');
+    expect(html).toMatch(/Source status/i);
+    expect(html).toMatch(/In context/i);
+    expect(html).toMatch(/Related laws/i);
+    expect(html).toContain('/category/murphys-technology-laws');
+    expect(html).toContain('/contact');
+  });
+
+  it('renders static homepage content around the primary loops', () => {
+    const html = buildStaticHomeContent();
+
+    expect(html).toContain('Search the Archive');
+    expect(html).toContain('Human-reviewed submissions');
+    expect(html).toContain('/categories');
+    expect(html).toContain('/submit');
+    expect(html).not.toMatch(/Loading/i);
   });
 });

--- a/web/tests/structured-data.test.ts
+++ b/web/tests/structured-data.test.ts
@@ -270,6 +270,19 @@ describe('Structured Data module', () => {
       expect(data.hasPart[1]['@type']).toBe('WebApplication');
     });
 
+    it('uses canonical calculator URLs in home hasPart', () => {
+      setHomeStructuredData();
+
+      const el = document.head.querySelector('#jsonld-home-page');
+      const data = JSON.parse(el!.textContent!);
+      const urls = data.hasPart.map((part: { url: string }) => part.url);
+
+      expect(urls).toContain('https://murphys-laws.com/calculator/sods-law');
+      expect(urls).toContain('https://murphys-laws.com/calculator/buttered-toast');
+      expect(urls).not.toContain('https://murphys-laws.com/calculator');
+      expect(urls).not.toContain('https://murphys-laws.com/toastcalculator');
+    });
+
     it('clears previous page data', () => {
       setJsonLd('browse-page', { name: 'Browse' });
       setHomeStructuredData();

--- a/web/tests/submit-law.test.ts
+++ b/web/tests/submit-law.test.ts
@@ -84,6 +84,14 @@ describe('SubmitLawSection component', () => {
     expect(el.querySelector('#submit-btn') as HTMLButtonElement | null).toBeTruthy();
   });
 
+  it('renders pre-submit guidance about review, attribution, and duplicates', () => {
+    const el = mountSection();
+
+    expect(el.textContent).toMatch(/reviewed by a human/i);
+    expect(el.textContent).toMatch(/attribution/i);
+    expect(el.textContent).toMatch(/duplicates/i);
+  });
+
   it('submit button is disabled initially', () => {
     const el = mountSection();
     const submitBtn = el.querySelector('#submit-btn') as HTMLButtonElement | null;


### PR DESCRIPTION
## Summary
- Render meaningful static content for core web routes called out in the site audit: homepage, developers, favorites, submit, calculators, categories, and law detail pages.
- Expand archive destination templates with richer law detail context, grouped category hubs, stronger cornerstone content, canonical structured data, and privacy-safe product metrics.
- Bump required release metadata for root, web, iOS, and Android after shared/web changes.

## Test plan
- [x] `npm run ci:web`
- [x] pre-commit hook checks, including backend/web coverage and web E2E

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ravidorr/murphys-laws/116)
<!-- Reviewable:end -->
