### PR TITLE
fix(web): suppress autocomplete network noise in Sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - iOS skeleton-loading shimmer now consumes `DS.Color.mutedFg` (light + dark from the Asset Catalog) instead of hand-branching on `@Environment(\.colorScheme)` with hardcoded `Color(white:)` greys. [ios/MurphysLaws/Views/Home/SkeletonViews.swift](ios/MurphysLaws/Views/Home/SkeletonViews.swift). The dark-mode swap is now driven by the system trait collection via `Assets.xcassets/DS/muted-fg.colorset`, matching how every other DS color works. PR iOS-2 of the design-tokens-mobile rollout; calculator and vote-thumb surfaces are explicitly out of scope (HIG-idiomatic semantic colors `.green` / `.orange` / `.red` are correct on iOS), and no rank-style surface exists on iOS to migrate yet. iOS app bumped to `1.0.2` / build `3`; root to `2.4.17`.
 
 ### Fixed
+- Autocomplete suggestions no longer report transient mobile fetch failures to
+  Sentry while still failing quietly for users. Web bumped to `3.2.14`; root to
+  `2.4.39`.
 - iOS skeleton loading placeholders now hide their source shapes under the
   shimmer overlay while preserving circular and rounded silhouettes, preventing
   content bleed during loading states. iOS app bumped to `1.1.9` / build `13`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.4.38",
+  "version": "2.4.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murphys-laws-monorepo",
-      "version": "2.4.38",
+      "version": "2.4.39",
       "license": "CC0-1.0",
       "workspaces": [
         "backend",
@@ -30,7 +30,7 @@
     },
     "backend": {
       "name": "murphys-laws-backend",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "CC0-1.0",
       "dependencies": {
         "@sentry/node": "^9.47.1",
@@ -16252,7 +16252,7 @@
     },
     "web": {
       "name": "murphys-laws-web",
-      "version": "3.2.12",
+      "version": "3.2.14",
       "license": "CC0-1.0",
       "dependencies": {
         "@sentry/browser": "^10.25.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.4.38",
+  "version": "2.4.39",
   "description": "Murphy's Laws - Monorepo for Web, iOS, and Android apps",
   "private": true,
   "workspaces": [

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-web",
-  "version": "3.2.13",
+  "version": "3.2.14",
   "description": "Murphy's Laws Web Application",
   "type": "module",
   "scripts": {

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -3,6 +3,20 @@ import * as Sentry from '@sentry/browser';
 import { API_BASE_URL, DEFAULT_FETCH_HEADERS } from './constants.ts';
 import type { Law, Category, PaginatedResponse, RelatedLawsResponse, ListResponse } from '../types/app.d.ts';
 
+function isFetchTransportError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return (
+    error.name === 'AbortError' ||
+    (
+      error instanceof TypeError &&
+      /networkerror.*fetch|failed to fetch|load failed|network request failed/i.test(error.message)
+    )
+  );
+}
+
 /**
  * Fetches from API with automatic fallback
  * @param {string} endpoint - API endpoint (e.g., '/api/v1/laws')
@@ -210,7 +224,9 @@ export async function fetchSuggestions({ q, limit = 10 }: { q?: string | null; l
     return await fetchAPI('/api/v1/laws/suggestions', params) as PaginatedResponse<Law>;
   } catch (error) {
     // Gracefully handle errors - return empty array
-    Sentry.captureException(error);
+    if (!isFetchTransportError(error)) {
+      Sentry.captureException(error);
+    }
     return { data: [], total: 0, limit: 0, offset: 0 };
   }
 }

--- a/web/tests/api.test.ts
+++ b/web/tests/api.test.ts
@@ -668,6 +668,16 @@ describe('API utilities', () => {
       expect(Sentry.captureException).toHaveBeenCalledWith(expect.any(Error));
     });
 
+    it('returns empty array without reporting transient fetch transport failures', async () => {
+      vi.mocked(Sentry.captureException).mockClear();
+      fetchSpy.mockRejectedValue(new TypeError('NetworkError while fetching'));
+
+      const result = await fetchSuggestions({ q: 'test' });
+
+      expect(result).toEqual({ data: [], total: 0, limit: 0, offset: 0 });
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+    });
+
     it('returns empty array when API request fails', async () => {
       fetchSpy.mockResolvedValueOnce({ ok: false, status: 500 });
 


### PR DESCRIPTION
## Summary

- Suppress transient fetch transport errors from autocomplete suggestions so mobile browser network aborts do not become Sentry noise.
- Keep API/server response failures reporting to Sentry, and bump root/web patch versions with a changelog entry.

## Test plan

- [x] npm run test:web -- --run tests/api.test.ts
- [x] cd web && npm run typecheck
- [x] npm run check:versions
- [x] commit hook: backend checks, web checks, coverage, E2E, lint-staged

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ravidorr/murphys-laws/117)
<!-- Reviewable:end -->
