### PR TITLE
fix(web): polish archive UI cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Work Sans variable font bundled in the Android app for visual parity with web. [android/app/src/main/res/font/work_sans_variable.ttf](android/app/src/main/res/font/work_sans_variable.ttf) (~360 KB, single VF covers all weights via the `wght` axis), wrapped by a hand-authored `WorkSans` `FontFamily` in [android/app/src/main/java/com/murphyslaws/ui/theme/WorkSans.kt](android/app/src/main/java/com/murphyslaws/ui/theme/WorkSans.kt). The FontFamily registers the variable font at four weight slots (Normal 400, Medium 500, SemiBold 600, Bold 700) with `FontVariation.Settings(FontVariation.weight(...))` so Compose's typography system resolves `.weight(...)` requests to the correct axis position. Requires API 26+, which matches the app's `minSdk`. [shared/design-tokens/export-android-tokens.ts](shared/design-tokens/export-android-tokens.ts) now emits `fontFamily = WorkSans` for every `DS.Typography.<level>`, replacing the `FontFamily.Default` (Roboto) placeholder from PR Android-1. PR Android-3 (final phase) of the design-tokens-mobile rollout. Bundling a new font is user-visible, so Android app bumped MINOR to `1.1.0` / versionCode `4`; root to `2.4.23`.
 
 ### Changed
+- Web archive UI polish now formats homepage proof points and Daily Law
+  distribution links as design-system chips, removes the extra Trending /
+  Recently Added wrapper heading, aligns law-list card dividers with other
+  cards, shows a fallback when related laws are empty, shortens the technology
+  hub intro to avoid clipping, and falls back to readable calculator formulas
+  when MathJax is unavailable. Web bumped to `3.3.1`; iOS app bumped to
+  `1.2.1` / build `17`; Android app bumped to `1.2.1` / versionCode `8`;
+  root to `2.5.1`.
 - Web site audit surfaces now render useful static content for core internal
   routes, including homepage, developers, favorites, submit, calculators,
   categories, and law detail pages. The archive experience now has richer law

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -17,8 +17,8 @@ android {
         applicationId = "com.murphyslaws"
         minSdk = 26
         targetSdk = 36
-        versionCode = 7
-        versionName = "1.2.0"
+        versionCode = 8
+        versionName = "1.2.1"
 
         testInstrumentationRunner = "com.murphyslaws.CustomTestRunner"
         vectorDrawables {

--- a/ios/MurphysLaws/Info.plist
+++ b/ios/MurphysLaws/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.0</string>
+	<string>1.2.1</string>
 	<key>CFBundleVersion</key>
-	<string>16</string>
+	<string>17</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>Save and share Murphy's Laws as images</string>
 	<key>UIAppFonts</key>

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -7,8 +7,8 @@ options:
   xcodeVersion: "14.0"
 
 settings:
-  MARKETING_VERSION: "1.2.0"
-  CURRENT_PROJECT_VERSION: "16"
+  MARKETING_VERSION: "1.2.1"
+  CURRENT_PROJECT_VERSION: "17"
 
 targets:
   MurphysLaws:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murphys-laws-monorepo",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "CC0-1.0",
       "workspaces": [
         "backend",
@@ -16252,7 +16252,7 @@
     },
     "web": {
       "name": "murphys-laws-web",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "CC0-1.0",
       "dependencies": {
         "@sentry/browser": "^10.25.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Murphy's Laws - Monorepo for Web, iOS, and Android apps",
   "private": true,
   "workspaces": [

--- a/shared/content/murphys-laws-about-technology.md
+++ b/shared/content/murphys-laws-about-technology.md
@@ -1,6 +1,6 @@
 # Murphy's Laws About Technology
 
-Technology gives Murphy's Law more places to hide. A failure can start in code, configuration, dependencies, hardware, networks, permissions, documentation, or the one setting nobody remembers changing.
+Technology gives Murphy's Law more places to hide. Failure can start in code, configuration, dependencies, hardware, networks, permissions, or documentation.
 
 ## Common technology patterns
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-web",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Murphy's Laws Web Application",
   "type": "module",
   "scripts": {

--- a/web/scripts/ssg.ts
+++ b/web/scripts/ssg.ts
@@ -669,11 +669,11 @@ function buildStaticHomeContent(): string {
           <p class="section-subtitle">Explore Murphy's Law history, browse thousands of laws, and find the category that fits your next mishap.</p>
         </div>
         <div class="section-body">
-          <div class="home-proof-points">
-            <span>2,400+ laws</span>
-            <span>55+ categories</span>
-            <span>Human-reviewed submissions</span>
-            <span>Curated since the late 1990s</span>
+          <div class="home-proof-points" aria-label="Archive facts">
+            <span class="home-proof-point"><strong>2,400+</strong><span>laws</span></span>
+            <span class="home-proof-point"><strong>55+</strong><span>categories</span></span>
+            <span class="home-proof-point"><strong>Human-reviewed</strong><span>submissions</span></span>
+            <span class="home-proof-point"><strong>Curated</strong><span>since 1998</span></span>
           </div>
           <div class="not-found-actions">
             <a href="/browse" class="btn">Browse All Laws</a>

--- a/web/src/components/law-list-section.ts
+++ b/web/src/components/law-list-section.ts
@@ -20,7 +20,7 @@ import type { Law } from '../types/app.d.ts';
  */
 export function createLawListSection({ accentText, remainderText }: { accentText: string; remainderText: string }) {
   const el = document.createElement('div');
-  el.className = 'card';
+  el.className = 'card law-list-card';
   // Reserve space for law cards to prevent layout shift (using LAW_CARD_MIN_HEIGHT constant)
   el.style.minHeight = `${LAW_CARD_MIN_HEIGHT}px`;
 

--- a/web/src/components/law-of-day.ts
+++ b/web/src/components/law-of-day.ts
@@ -111,14 +111,12 @@ export function LawOfTheDay({ law, onNavigate }: { law: Law | null; onNavigate: 
 
   const distribution = document.createElement('div');
   distribution.setAttribute('data-daily-law-distribution', '');
-  distribution.className = 'small text-muted-fg mt-4';
+  distribution.className = 'daily-law-distribution';
   distribution.innerHTML = `
-    <strong>Daily Law distribution:</strong>
-    <a href="/api/v1/feed.rss">RSS</a>
-    <span aria-hidden="true"> · </span>
-    <a href="/api/v1/feed.atom">Atom</a>
-    <span aria-hidden="true"> · </span>
-    <a href="/api/v1/law-of-day">Daily Law API</a>
+    <span class="daily-law-distribution-label">Daily Law distribution</span>
+    <a class="daily-law-distribution-link" href="/api/v1/feed.rss">RSS</a>
+    <a class="daily-law-distribution-link" href="/api/v1/feed.atom">Atom</a>
+    <a class="daily-law-distribution-link" href="/api/v1/law-of-day">Daily Law API</a>
   `;
   el.appendChild(distribution);
 

--- a/web/src/components/trending.ts
+++ b/web/src/components/trending.ts
@@ -16,7 +16,7 @@ import { LAW_CARD_MIN_HEIGHT, WIDGET_CARD_COUNT } from '../utils/constants.ts';
  */
 export function Trending() {
   const el = document.createElement('div');
-  el.className = 'card';
+  el.className = 'card law-list-card';
   // Reserve space for law cards to prevent layout shift (using LAW_CARD_MIN_HEIGHT constant)
   el.style.minHeight = `${LAW_CARD_MIN_HEIGHT}px`;
 

--- a/web/src/views/buttered-toast-calculator.ts
+++ b/web/src/views/buttered-toast-calculator.ts
@@ -83,7 +83,7 @@ export function ButteredToastCalculator(): HTMLDivElement {
     const F = parseFloat(sliders.friction.value);
     const T = parseFloat(sliders.inertia.value);
 
-    // Generate LaTeX formula - show variable name or value based on showValues
+    // Generate formula - use MathJax only when available, otherwise show readable text.
     const hDisplay = showValues.H ? H : 'H';
     const gDisplay = showValues.g ? g : 'g';
     const oDisplay = showValues.O ? O : 'O';
@@ -91,19 +91,23 @@ export function ButteredToastCalculator(): HTMLDivElement {
     const fDisplay = showValues.F ? F : 'F';
     const tDisplay = showValues.T ? T : 'T';
 
-    const formula = `\\(P_{\\text{butter-down}} = \\left(1 - \\left| \\left( \\frac{30 \\sqrt{\\frac{${hDisplay}}{${gDisplay}}} \\cdot ${oDisplay} \\cdot ${bDisplay}}{${tDisplay} + ${fDisplay}} \\bmod{1} \\right) - 0.5 \\right| \\cdot 2 \\right) \\cdot 100\\% \\)`;
+    const readableFormula = `Butter-down probability = rotation from height ${hDisplay}, gravity ${gDisplay}, push ${oDisplay}, butter ${bDisplay}, drag ${fDisplay}, and density ${tDisplay}`;
+    const mathFormula = `\\(P_{\\text{butter-down}} = \\left(1 - \\left| \\left( \\frac{30 \\sqrt{\\frac{${hDisplay}}{${gDisplay}}} \\cdot ${oDisplay} \\cdot ${bDisplay}}{${tDisplay} + ${fDisplay}} \\bmod{1} \\right) - 0.5 \\right| \\cdot 2 \\right) \\cdot 100\\% \\)`;
 
-    formulaDisplay.textContent = formula;
+    formulaDisplay.textContent = readableFormula;
     if (window.MathJax && typeof window.MathJax.typesetPromise === 'function') {
       // Capture MathJax reference to avoid race conditions in test environments
       const mathJax = window.MathJax;
+      formulaDisplay.textContent = mathFormula;
       requestAnimationFrame(() => {
         // Defensive check: MathJax might become undefined in test environments
         if (!mathJax || typeof mathJax.typesetPromise !== 'function') {
+          formulaDisplay.textContent = readableFormula;
           return;
         }
 
         mathJax.typesetPromise([formulaDisplay as HTMLElement]).then(() => {
+          /* v8 ignore start -- tooltip decoration depends on MathJax-rendered DOM in browsers */
           // Add title attributes to variables after MathJax renders
           const titles: Record<string, string> = {
             'H': 'Height of Fall (30-200 cm)',
@@ -149,8 +153,9 @@ export function ButteredToastCalculator(): HTMLDivElement {
             }
             /* v8 ignore stop */
           });
+          /* v8 ignore stop */
         }).catch(() => {
-          // Silently handle MathJax errors
+          formulaDisplay.textContent = readableFormula;
         });
       });
     }
@@ -258,6 +263,7 @@ export function ButteredToastCalculator(): HTMLDivElement {
 
   // Initialize calculation on load
   calculateLanding();
+  updateFormula();
 
   // Initialize formula after MathJax is loaded
   ensureMathJax()

--- a/web/src/views/home.ts
+++ b/web/src/views/home.ts
@@ -30,11 +30,11 @@ const ARCHIVE_SEARCH_HTML = `
           <span class="icon" data-icon="search" aria-hidden="true"></span>
         </button>
       </form>
-      <div class="home-proof-points">
-        <span>2,400+ laws</span>
-        <span>55+ categories</span>
-        <span>Human-reviewed submissions</span>
-        <span>Curated since the late 1990s</span>
+      <div class="home-proof-points" aria-label="Archive facts">
+        <span class="home-proof-point"><strong>2,400+</strong><span>laws</span></span>
+        <span class="home-proof-point"><strong>55+</strong><span>categories</span></span>
+        <span class="home-proof-point"><strong>Human-reviewed</strong><span>submissions</span></span>
+        <span class="home-proof-point"><strong>Curated</strong><span>since 1998</span></span>
       </div>
       <a href="/browse" class="btn primary" data-nav="browse">
         <span class="btn-text">Browse All Laws</span>
@@ -162,13 +162,8 @@ export function renderHome(el: HTMLElement, lawOfTheDay: Law | null, _categories
   const trendingRecentZone = document.createElement('section');
   trendingRecentZone.setAttribute('data-home-zone', 'trending-recent');
   trendingRecentZone.className = 'section mb-12';
-  trendingRecentZone.innerHTML = `
-    <div class="section-header">
-      <h2 class="section-title"><span class="accent-text">Trending</span> and Recently Added</h2>
-    </div>
-  `;
   const discoveryGrid = document.createElement('div');
-  discoveryGrid.className = 'grid gap-4 md:grid-cols-2';
+  discoveryGrid.className = 'home-discovery-grid';
   discoveryGrid.appendChild(Trending());
   discoveryGrid.appendChild(RecentlyAdded());
   trendingRecentZone.appendChild(discoveryGrid);

--- a/web/src/views/law-detail.ts
+++ b/web/src/views/law-detail.ts
@@ -346,6 +346,18 @@ export function LawDetail({ lawId, onNavigate, onStructuredData }: LawDetailProp
         initSharePopovers(relatedList as HTMLElement);
         addVotingListeners(relatedList as HTMLElement);
         relatedSection.removeAttribute('hidden');
+      } else {
+        relatedList.innerHTML = `
+          <div class="empty-state">
+            <p class="empty-state-title">No direct related laws yet</p>
+            <p class="empty-state-text">Keep exploring nearby archive entries instead.</p>
+            <div class="not-found-actions">
+              <a href="/browse" class="btn outline" data-nav="browse">Browse all laws</a>
+              <a href="/categories" class="btn outline" data-nav="categories">Browse categories</a>
+            </div>
+          </div>
+        `;
+        relatedSection.removeAttribute('hidden');
       }
     } catch {
       // Silently fail - related laws are not critical

--- a/web/src/views/sods-calculator.ts
+++ b/web/src/views/sods-calculator.ts
@@ -99,7 +99,7 @@ export function Calculator(): HTMLDivElement {
       data: `Probability of things going wrong: ${displayPercent}%. ${interpretation}`
     });
 
-    // Generate LaTeX formula - show variable name or value based on showValues
+    // Generate formula - use MathJax only when available, otherwise show readable text.
     const pFormula = showValues.U ? String(displayPercent) : 'P';
     const uDisplay = showValues.U ? U : 'U';
     const cDisplay = showValues.C ? C : 'C';
@@ -107,19 +107,22 @@ export function Calculator(): HTMLDivElement {
     const sDisplay = showValues.S ? S : 'S';
     const fDisplay = showValues.F ? F : 'F';
     const aDisplay = showValues.U ? '0.7' : 'A'; // Show 0.7 when flashing
+    const readableFormula = `Probability = ((${uDisplay} + ${cDisplay} + ${iDisplay}) x (10 - ${sDisplay}) / 20) x ${aDisplay} x 1 / (1 - sin(${fDisplay} / 10))`;
+    const mathFormula = `\\(${pFormula}=\\frac{((${uDisplay}+${cDisplay}+${iDisplay})\\times (10-${sDisplay}))}{20}\\times ${aDisplay}\\times \\frac{1}{(1-\\sin (\\frac{${fDisplay}}{10}))}\\)`;
 
-    const formula = `\\(${pFormula}=\\frac{((${uDisplay}+${cDisplay}+${iDisplay})\\times (10-${sDisplay}))}{20}\\times ${aDisplay}\\times \\frac{1}{(1-\\sin (\\frac{${fDisplay}}{10}))}\\)`;
-
-    formulaDisplay.textContent = formula;
+    formulaDisplay.textContent = readableFormula;
     if (window.MathJax && typeof window.MathJax.typesetPromise === 'function') {
       // Capture MathJax reference to avoid race conditions in test environments
       const mathJax = window.MathJax;
+      formulaDisplay.textContent = mathFormula;
       requestAnimationFrame(() => {
         if (!mathJax || typeof mathJax.typesetPromise !== 'function') {
+          formulaDisplay.textContent = readableFormula;
           return;
         }
 
         mathJax.typesetPromise([formulaDisplay as HTMLElement]).then(() => {
+          /* v8 ignore start -- tooltip decoration depends on MathJax-rendered DOM in browsers */
           // Add title attributes to variables after MathJax renders
           const titles: Record<string, string> = {
             'U': 'Urgency (1-9)',
@@ -164,8 +167,9 @@ export function Calculator(): HTMLDivElement {
             }
             /* v8 ignore stop */
           });
+          /* v8 ignore stop */
         }).catch(() => {
-          // Silently handle MathJax errors
+          formulaDisplay.textContent = readableFormula;
         });
       });
     }

--- a/web/styles/partials/sections.css
+++ b/web/styles/partials/sections.css
@@ -28,6 +28,36 @@
   line-height: 1.7;
 }
 
+.home-proof-points {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin: var(--space-3) 0 var(--space-4);
+}
+
+.home-proof-point {
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--space-1);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background: color-mix(in oklab, var(--bg) 96%, var(--muted-fg) 4%);
+  color: var(--muted-fg);
+  font-size: 0.875rem;
+  line-height: 1.25;
+}
+
+.home-proof-point strong {
+  color: var(--fg);
+  font-weight: 600;
+}
+
+.home-discovery-grid {
+  display: grid;
+  gap: 3rem;
+}
+
 .feature-list {
   list-style: none;
   padding: 0;
@@ -522,6 +552,41 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
+}
+
+.daily-law-distribution {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  border-top: 1px solid var(--border);
+  color: var(--muted-fg);
+  font-size: var(--text-sm);
+  line-height: var(--leading-tight);
+}
+
+.daily-law-distribution-label {
+  color: var(--fg);
+  font-weight: var(--font-semibold);
+}
+
+.daily-law-distribution-link {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background: color-mix(in oklab, var(--bg) 96%, var(--muted-fg) 4%);
+  color: var(--link);
+  text-decoration: none;
+}
+
+.daily-law-distribution-link:hover,
+.daily-law-distribution-link:focus-visible {
+  color: var(--link-hover);
+  border-color: color-mix(in oklab, var(--border) 70%, var(--link) 30%);
+  background: color-mix(in oklab, var(--bg) 92%, var(--link) 8%);
 }
 
 .count-up,
@@ -1088,6 +1153,15 @@
   padding: 0 1rem 0.75rem;
   margin: 0;
   border-bottom: 1px solid var(--border);
+}
+
+.card.law-list-card .card-title {
+  padding: 0;
+  border-bottom: none;
+}
+
+.card.law-list-card .card-body {
+  padding: 0;
 }
 
 .card .card-text {

--- a/web/tests/buttered-toast-calculator.test.ts
+++ b/web/tests/buttered-toast-calculator.test.ts
@@ -25,6 +25,37 @@ describe('ButteredToastCalculator view', () => {
     document.body.removeChild(el);
   });
 
+
+  it('updates toast social image meta tags when present', () => {
+    const og = document.createElement('meta');
+    og.setAttribute('property', 'og:image');
+    const twitter = document.createElement('meta');
+    twitter.setAttribute('property', 'twitter:image');
+    document.head.append(og, twitter);
+
+    const el = ButteredToastCalculator();
+    document.body.appendChild(el);
+
+    expect(og.getAttribute('content')).toContain('/social/buttered-toast-calculator.png');
+    expect(twitter.getAttribute('content')).toContain('/social/buttered-toast-calculator.png');
+    document.body.removeChild(el);
+    og.remove();
+    twitter.remove();
+  });
+
+  it('shows a readable formula fallback when MathJax is unavailable', () => {
+    const originalMathJax = window.MathJax;
+    window.MathJax = undefined;
+    const el = ButteredToastCalculator();
+    document.body.appendChild(el);
+
+    expect(el.querySelector('#toast-formula-display')?.textContent).toContain('Butter-down probability');
+    expect(el.querySelector('#toast-formula-display')?.textContent).not.toContain('\\(');
+
+    window.MathJax = originalMathJax;
+    document.body.removeChild(el);
+  });
+
   it('L33 B0: twitter:image branch not taken when absent', () => {
     const el = ButteredToastCalculator();
     document.body.appendChild(el);

--- a/web/tests/calculator-state.test.ts
+++ b/web/tests/calculator-state.test.ts
@@ -44,4 +44,13 @@ describe('calculator state', () => {
 
     expect(state).toEqual({ u: 9, i: 4, f: 1 });
   });
+
+  it('skips non-finite serialized values', () => {
+    const url = serializeCalculatorState('https://murphys-laws.com/calculator/sods-law', {
+      u: 5,
+      c: Number.NaN,
+    });
+
+    expect(url).toBe('https://murphys-laws.com/calculator/sods-law?u=5');
+  });
 });

--- a/web/tests/developers.test.ts
+++ b/web/tests/developers.test.ts
@@ -47,6 +47,17 @@ describe('Developers page', () => {
     expect(navigated).toBe(false);
   });
 
+  it('ignores non-HTMLElement click targets', () => {
+    let navigated = false;
+    const el = Developers({ onNavigate: () => { navigated = true; } });
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    el.appendChild(svg);
+
+    svg.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(navigated).toBe(false);
+  });
+
   it('navigates when a data-nav target is clicked', () => {
     let target = '';
     const el = Developers({ onNavigate: (next) => { target = next; } });

--- a/web/tests/discovery.test.ts
+++ b/web/tests/discovery.test.ts
@@ -25,4 +25,8 @@ describe('discovery helpers', () => {
     expect(ranked[0]!.id).toBe(1);
     expect(ranked[0]!.score).toBeGreaterThan(ranked[1]!.score);
   });
+
+  it('returns null when no category can be inferred', () => {
+    expect(inferDiscoveryCategory('plain unclassified words')).toBeNull();
+  });
 });

--- a/web/tests/home.test.ts
+++ b/web/tests/home.test.ts
@@ -15,7 +15,21 @@ describe('Home view', () => {
     expect(el.querySelector('[data-home-zone="category-discovery"]')).toBeTruthy();
     expect(el.querySelector('[data-home-zone="tools-submit"]')).toBeTruthy();
     expect(el.querySelector('[data-home-zone="trending-recent"]')).toBeTruthy();
+    expect(el.querySelector('[data-home-zone="trending-recent"] > .section-header')).toBeNull();
+    expect(el.querySelector('[data-home-zone="trending-recent"] .home-discovery-grid')).toBeTruthy();
     expect(el.textContent).toMatch(/human-reviewed/i);
+  });
+
+  it('renders proof points as spaced token-friendly badges', () => {
+    const el = document.createElement('div');
+
+    renderHome(el, { id: 1, text: 'Test law', upvotes: 0, downvotes: 0 }, [], () => {});
+
+    const proofPoints = el.querySelectorAll('.home-proof-point');
+    expect(proofPoints).toHaveLength(4);
+    expect(proofPoints[0]?.querySelector('strong')?.textContent).toBe('2,400+');
+    expect(proofPoints[0]?.querySelector('span')?.textContent).toBe('laws');
+    expect(proofPoints[3]?.textContent).toContain('since 1998');
   });
 
   it('routes homepage search submissions to browse', () => {
@@ -30,7 +44,6 @@ describe('Home view', () => {
 
     expect(onNavigate).toHaveBeenCalledWith('browse');
   });
-
   it('renders Law of the Day after fetching data', async () => {
     const lawOfTheDay = {
       id: '1',

--- a/web/tests/internal-links.test.ts
+++ b/web/tests/internal-links.test.ts
@@ -30,12 +30,25 @@ describe('internal links', () => {
     ]);
   });
 
+  it('uses a generic label when category name is missing', () => {
+    const links = getLawDetailInternalLinks({ categorySlug: 'uncategorized' });
+
+    expect(links[0]!.label).toBe('Same category');
+  });
+
   it('builds category hub links with related category and hub destinations', () => {
     const links = getCategoryHubLinks('murphys-travel-laws');
 
     expect(links.map((link) => link.href)).toContain('/examples/travel');
     expect(links.map((link) => link.href)).toContain('/category/murphys-bus-laws');
     expect(links.map((link) => link.href)).toContain('/calculator/sods-law');
+  });
+
+  it('returns fallback category hub links for unknown categories', () => {
+    expect(getCategoryHubLinks('unknown-category').map((link) => link.href)).toEqual([
+      '/best-murphys-laws',
+      '/categories'
+    ]);
   });
 
   it('builds calculator scenario links', () => {

--- a/web/tests/law-detail.test.ts
+++ b/web/tests/law-detail.test.ts
@@ -959,11 +959,9 @@ describe('LawDetail view', () => {
 
     await new Promise(r => setTimeout(r, 100));
 
-    // Related section should remain hidden
     const relatedSection = el.querySelector('[data-related-laws]');
-    if (relatedSection) {
-      expect(relatedSection.hasAttribute('hidden')).toBe(true);
-    }
+    expect(relatedSection?.hasAttribute('hidden')).toBe(false);
+    expect(relatedSection?.textContent).toContain('Browse all laws');
   });
 
   it('handles related laws with null data', async () => {

--- a/web/tests/law-list-section.test.ts
+++ b/web/tests/law-list-section.test.ts
@@ -9,7 +9,8 @@ describe('LawListSection component', () => {
     });
 
     expect(el.tagName).toBe('DIV');
-    expect(el.className).toBe('card');
+    expect(el.classList.contains('card')).toBe(true);
+    expect(el.classList.contains('law-list-card')).toBe(true);
   });
 
   it('renders title with accent and remainder text', () => {

--- a/web/tests/law-of-day.test.ts
+++ b/web/tests/law-of-day.test.ts
@@ -138,6 +138,8 @@ describe('LawOfTheDay component', () => {
     const el = mountLaw(law);
 
     expect(el.querySelector('[data-daily-law-distribution]')).toBeTruthy();
+    expect(el.querySelector('[data-daily-law-distribution]')?.classList.contains('daily-law-distribution')).toBe(true);
+    expect(el.querySelectorAll('.daily-law-distribution-link')).toHaveLength(3);
     expect(el.querySelector('[data-daily-law-distribution]')?.innerHTML).toContain('/api/v1/feed.rss');
     expect(el.querySelector('[data-daily-law-distribution] a:last-of-type')?.getAttribute('href')).toBe('/api/v1/law-of-day');
     expect(el.querySelector('[data-daily-law-distribution]')?.textContent).toContain('Daily Law');

--- a/web/tests/markdown-content.test.ts
+++ b/web/tests/markdown-content.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
 import { getPageContent, getPageMetadata, getRawMarkdownContent, markdownToHtml, type ContentPage } from '../src/utils/markdown-content.ts';
 import { marked } from 'marked';
+import { ContentPageView } from '../src/views/content-page.ts';
+import * as exportContext from '../src/utils/export-context.ts';
 
 describe('markdown-content.js', () => {
   describe('markdownToHtml', () => {
@@ -91,6 +93,10 @@ describe('markdown-content.js', () => {
       expect(getPageContent('murphys-law-vs-sods-law')).toContain('Sod');
     });
 
+    it('uses concise technology hub intro copy to avoid visual clipping', () => {
+      expect(getPageContent('murphys-laws-about-technology')).not.toContain('the one setting nobody remembers changing');
+    });
+
     it('returns HTML content for examples subpages', () => {
       expect(getPageContent('examples/work')).toContain('Work');
       expect(getPageContent('examples/travel')).toContain('Travel');
@@ -160,6 +166,79 @@ describe('markdown-content.js', () => {
       expect(() => {
         getPageContent('unknown-page' as ContentPage);
       }).toThrow();
+    });
+  });
+
+
+  describe('ContentPageView', () => {
+    it('renders a content page view with export cleanup', () => {
+      const clearExportSpy = vi.spyOn(exportContext, 'clearExportContent');
+      const el = ContentPageView({
+        page: 'best-murphys-laws',
+        title: "Best Murphy's Laws",
+        description: 'Best laws page',
+        onNavigate: () => {}
+      });
+
+      expect(el.className).toContain('content-page');
+      expect(document.title).toContain("Best Murphy's Laws");
+      expect(el.textContent).toContain('Best');
+      const cleanable = el as HTMLDivElement & { cleanup?: () => void };
+      expect(cleanable.cleanup).toBeTypeOf('function');
+      cleanable.cleanup!();
+      expect(clearExportSpy).toHaveBeenCalled();
+    });
+
+    it('handles content page navigation clicks', () => {
+      const onNavigate = vi.fn();
+      const el = ContentPageView({
+        page: 'best-murphys-laws',
+        title: "Best Murphy's Laws",
+        description: 'Best laws page',
+        onNavigate
+      });
+      const link = document.createElement('a');
+      link.setAttribute('data-nav', 'browse');
+      el.appendChild(link);
+
+      link.click();
+
+      expect(onNavigate).toHaveBeenCalledWith('browse');
+    });
+
+    it('ignores content page clicks without actionable navigation', () => {
+      const onNavigate = vi.fn();
+      const el = ContentPageView({
+        page: 'best-murphys-laws',
+        title: "Best Murphy's Laws",
+        description: 'Best laws page',
+        onNavigate
+      });
+      const emptyNav = document.createElement('a');
+      emptyNav.setAttribute('data-nav', '');
+      el.appendChild(emptyNav);
+
+      emptyNav.click();
+      el.click();
+
+      expect(onNavigate).not.toHaveBeenCalled();
+    });
+
+
+    it('ignores non-HTMLElement click targets', () => {
+      const onNavigate = vi.fn();
+      const el = ContentPageView({
+        page: 'best-murphys-laws',
+        title: "Best Murphy's Laws",
+        description: 'Best laws page',
+        onNavigate
+      });
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      el.appendChild(svg);
+
+      svg.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+      expect(onNavigate).not.toHaveBeenCalled();
     });
   });
 

--- a/web/tests/not-found.test.ts
+++ b/web/tests/not-found.test.ts
@@ -109,6 +109,30 @@ describe('NotFound view', () => {
     expect(searchInput).toBeTruthy();
   });
 
+  it('does not navigate for empty search query', () => {
+    const onNavigate = vi.fn();
+    el = NotFound({ onNavigate });
+    const searchForm = el.querySelector('#not-found-search-form');
+    const searchInput = el.querySelector('#not-found-search-input') as HTMLInputElement;
+    searchInput.value = '   ';
+
+    searchForm?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it('does not navigate when data-nav is empty', () => {
+    const onNavigate = vi.fn();
+    el = NotFound({ onNavigate });
+    const btn = document.createElement('button');
+    btn.setAttribute('data-nav', '');
+    el.appendChild(btn);
+
+    btn.click();
+
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
   it('stores search query in sessionStorage and navigates to browse on search', () => {
     const onNavigate = vi.fn();
     el = NotFound({ onNavigate });

--- a/web/tests/recently-added.test.ts
+++ b/web/tests/recently-added.test.ts
@@ -30,6 +30,7 @@ describe('RecentlyAdded component', () => {
     fetchRecentlyAddedSpy.mockReturnValue(new Promise(() => {})); // Never resolves
     const el = RecentlyAdded();
 
+    expect(el.classList.contains('law-list-card')).toBe(true);
     // Check for loading placeholder (uses random messages, not "Loading")
     expect(el.querySelector('.loading-placeholder')).toBeTruthy();
     expect(el.textContent).toContain('Recently Added');

--- a/web/tests/seo.test.ts
+++ b/web/tests/seo.test.ts
@@ -93,5 +93,9 @@ describe('SEO utilities', () => {
     it('removes www host variants and query strings from canonical URLs', () => {
       expect(buildCanonicalUrl('https://www.murphys-laws.com/browse?q=toast')).toBe('https://murphys-laws.com/browse');
     });
+
+    it('keeps root canonical URL slash', () => {
+      expect(buildCanonicalUrl('/')).toBe('https://murphys-laws.com/');
+    });
   });
 });

--- a/web/tests/sods-calculator.test.ts
+++ b/web/tests/sods-calculator.test.ts
@@ -68,8 +68,32 @@ describe("Calculator view", () => {
     expect(el!.querySelector('[data-calculator-scenario-links]')?.innerHTML).toContain('/examples/work');
   });
 
+  it('shows a readable formula fallback when MathJax is unavailable', () => {
+    const next = mountCalculator({ mathJaxStub: null });
+
+    expect(next.querySelector('#formula-display')?.textContent).toContain('Probability =');
+    expect(next.querySelector('#formula-display')?.textContent).not.toContain('\\(');
+  });
+
   it('L34 B0: og:image branch not taken when absent', () => {
     expect(el!.querySelector('#urgency')).toBeTruthy();
+  });
+
+
+  it('updates social image meta tags when present', () => {
+    const og = document.createElement('meta');
+    og.setAttribute('property', 'og:image');
+    const twitter = document.createElement('meta');
+    twitter.setAttribute('property', 'twitter:image');
+    document.head.append(og, twitter);
+
+    const next = mountCalculator();
+
+    expect(og.getAttribute('content')).toContain('/social/sods-calculator.png');
+    expect(twitter.getAttribute('content')).toContain('/social/sods-calculator.png');
+    next.cleanup?.();
+    og.remove();
+    twitter.remove();
   });
 
   it('L35 B0: twitter:image branch not taken when absent', () => {

--- a/web/tests/ssg.test.ts
+++ b/web/tests/ssg.test.ts
@@ -238,7 +238,10 @@ describe('SSG Static Route Content', () => {
     const html = buildStaticHomeContent();
 
     expect(html).toContain('Search the Archive');
-    expect(html).toContain('Human-reviewed submissions');
+    expect(html).toContain('Human-reviewed');
+    expect(html).toContain('submissions');
+    expect(html).toContain('since 1998');
+    expect(html).toContain('home-proof-point');
     expect(html).toContain('/categories');
     expect(html).toContain('/submit');
     expect(html).toContain('Trending and Recently Added');

--- a/web/tests/trending.test.ts
+++ b/web/tests/trending.test.ts
@@ -31,6 +31,7 @@ describe('Trending component', () => {
     fetchTrendingSpy.mockReturnValue(new Promise(() => {})); // Never resolves
     const el = Trending();
 
+    expect(el.classList.contains('law-list-card')).toBe(true);
     // Check for any of the possible loading messages (they're random)
     expect(el.textContent).toMatch(/Loading|Fetching|Almost there/);
   });


### PR DESCRIPTION
## Summary
- Format homepage proof points and Daily Law distribution as design-system chips.
- Remove the extra Trending/Recently Added wrapper heading and align law-list card dividers/spacing.
- Add law-detail related fallback, shorten clipped tech hub copy, and show readable calculator formulas when MathJax is unavailable.

## Test plan
- [x] `npm run ci:web`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ravidorr/murphys-laws/119)
<!-- Reviewable:end -->
