### PR TITLE
refactor(web): unify card surface classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Work Sans variable font bundled in the Android app for visual parity with web. [android/app/src/main/res/font/work_sans_variable.ttf](android/app/src/main/res/font/work_sans_variable.ttf) (~360 KB, single VF covers all weights via the `wght` axis), wrapped by a hand-authored `WorkSans` `FontFamily` in [android/app/src/main/java/com/murphyslaws/ui/theme/WorkSans.kt](android/app/src/main/java/com/murphyslaws/ui/theme/WorkSans.kt). The FontFamily registers the variable font at four weight slots (Normal 400, Medium 500, SemiBold 600, Bold 700) with `FontVariation.Settings(FontVariation.weight(...))` so Compose's typography system resolves `.weight(...)` requests to the correct axis position. Requires API 26+, which matches the app's `minSdk`. [shared/design-tokens/export-android-tokens.ts](shared/design-tokens/export-android-tokens.ts) now emits `fontFamily = WorkSans` for every `DS.Typography.<level>`, replacing the `FontFamily.Default` (Roboto) placeholder from PR Android-1. PR Android-3 (final phase) of the design-tokens-mobile rollout. Bundling a new font is user-visible, so Android app bumped MINOR to `1.1.0` / versionCode `4`; root to `2.4.23`.
 
 ### Changed
+- Web card surfaces now use a canonical card shell and variant class system
+  across section widgets, law-list widgets, category cards, content pages,
+  empty states, and law detail runtime/SSG output. Legacy class names remain as
+  compatibility aliases while the CSS now scopes list, content, section, empty,
+  and category card behavior through explicit variants. Web bumped to `3.3.2`;
+  root to `2.5.2`.
 - Web archive UI polish now formats homepage proof points and Daily Law
   distribution links as design-system chips, removes the extra Trending /
   Recently Added wrapper heading, aligns law-list card dividers with other

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murphys-laws-monorepo",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "license": "CC0-1.0",
       "workspaces": [
         "backend",
@@ -16252,7 +16252,7 @@
     },
     "web": {
       "name": "murphys-laws-web",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "CC0-1.0",
       "dependencies": {
         "@sentry/browser": "^10.25.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Murphy's Laws - Monorepo for Web, iOS, and Android apps",
   "private": true,
   "workspaces": [

--- a/web/DESIGN.md
+++ b/web/DESIGN.md
@@ -356,6 +356,49 @@ calculator state/result surfaces). Dark-mode overrides are handled in
 `theme.css`; agents should assume any component is theme-aware and use
 the `dark-*` color tokens for dark surfaces.
 
+## Card System
+
+Cards use one canonical shell plus explicit variants. Keep old class names as
+compatibility aliases while migrating markup; do not create new one-off card
+selectors.
+
+### Base Contract
+
+Use `card` for the outer surface. Use these regions inside it:
+
+- `card-header` for the title and summary area. Header dividers are full-width.
+- `card-title` for the title text only. It should not add its own divider.
+- `card-body` for normal padded content.
+- `card-body--flush` when the body contains full-width rows, such as law lists.
+- `card-footer` for full-width action or metadata rows.
+
+### Variants
+
+Use a variant class with `card` so the surface intent is explicit:
+
+- `card--section`: homepage widgets, Law of the Day, submit modules, advanced
+  search, and law-detail supporting sections. Legacy alias: `section-card`.
+- `card--content`: long-form Markdown/content pages with wider reading spacing.
+  Legacy alias: `content-card`.
+- `card--law-list`: stacked law-list widgets such as Top Voted, Trending Now,
+  and Recently Added. Legacy alias: `law-list-card`. The child rows remain
+  `law-card-mini` and are not standalone card shells.
+- `card--category`: category tiles. Use `category-card--rich` for the current
+  grouped category cards and `category-card--compact` only for older compact
+  directory tiles. Legacy alias: `category-card`.
+- `card--empty`: empty states such as 404 and empty favorites.
+
+### Rules
+
+- Do not use broad selectors like `.card .card-title` for variant-specific
+  behavior. Target the variant instead.
+- Do not add a second card system with parallel header/body/footer names.
+  `section-header`, `section-body`, and `section-footer` may remain for
+  semantic sections, but their visual behavior must map to card regions.
+- Runtime and SSG markup must use the same card shell for the same page type.
+- Dark mode, high-contrast mode, and print styles should target the canonical
+  variants first, with legacy aliases only for compatibility.
+
 ## Do's and Don'ts
 
 - Do keep type doing the heavy lifting. Chrome should be quiet.

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-web",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Murphy's Laws Web Application",
   "type": "module",
   "scripts": {

--- a/web/scripts/ssg.ts
+++ b/web/scripts/ssg.ts
@@ -285,7 +285,7 @@ function buildStaticLawDetailContent(law: Law): string {
           <li aria-current="page">${escapeHtml(title)}</li>
         </ol>
       </nav>
-      <article class="law-detail-card card">
+      <article class="card card--section law-detail-card">
         <header class="card-header">
           <h1 class="card-title">${escapeHtml(title)}</h1>
           <p class="small">Source status: ${sourceStatus}</p>
@@ -299,7 +299,7 @@ function buildStaticLawDetailContent(law: Law): string {
           </div>
         </div>
       </article>
-      <section class="section section-card mb-12" aria-labelledby="law-context-heading">
+      <section class="section card card--section section-card mb-12" aria-labelledby="law-context-heading">
         <div class="section-header">
           <h2 id="law-context-heading" class="section-title" data-section-title="In context"><span class="accent-text">In</span> context</h2>
         </div>
@@ -307,7 +307,7 @@ function buildStaticLawDetailContent(law: Law): string {
           <p>${escapeHtml(context)}</p>
         </div>
       </section>
-      <section class="section section-card mb-12" aria-labelledby="related-laws-heading">
+      <section class="section card card--section section-card mb-12" aria-labelledby="related-laws-heading">
         <div class="section-header">
           <h2 id="related-laws-heading" class="section-title" data-section-title="Related laws"><span class="accent-text">Related</span> laws</h2>
         </div>
@@ -320,7 +320,7 @@ function buildStaticLawDetailContent(law: Law): string {
           </div>
         </div>
       </section>
-      <section class="section section-card" aria-labelledby="law-actions-heading">
+      <section class="section card card--section section-card" aria-labelledby="law-actions-heading">
         <div class="section-header">
           <h2 id="law-actions-heading" class="section-title"><span class="accent-text">Improve</span> this entry</h2>
         </div>
@@ -555,7 +555,7 @@ function wrapInCardStructure(html: string, options: { lastUpdated?: string | nul
   if (!h1Match) {
     // No h1 found, wrap everything in card-body
     return `
-        <article class="card content-card">
+        <article class="card card--content content-card">
           <div class="card-body">
             ${html}
           </div>
@@ -594,7 +594,7 @@ function wrapInCardStructure(html: string, options: { lastUpdated?: string | nul
   }
   
   return `
-        <article class="card content-card">
+        <article class="card card--content content-card">
 ${headerHtml}
           <div class="card-body">
             ${bodyContent.trim()}
@@ -606,7 +606,7 @@ function buildStaticFavoritesContent(): string {
   return `
     <div class="container page">
       <h1 class="page-title mb-4" data-page-title="My Favorites"><span class="accent-text">My</span> Favorites</h1>
-      <article class="card content-card">
+      <article class="card card--empty content-card">
         <header class="card-header text-center">
           <h2 class="card-title"><span class="accent-text">Save</span> Laws You Want To Revisit</h2>
           <blockquote class="not-found-quote">
@@ -633,7 +633,7 @@ function buildStaticSubmitContent(): string {
   return `
     <div class="container page">
       <h1 class="page-title mb-4" data-page-title="Submit a Murphy's Law"><span class="accent-text">Submit</span> a Murphy's Law</h1>
-      <article class="card content-card">
+      <article class="card card--content content-card">
         <header class="card-header content-header">
           <h2 class="card-title"><span class="accent-text">Share</span> a Law With the Archive</h2>
           <p class="lead">Every submission is reviewed by a human before publication so the archive stays useful, readable, and trustworthy.</p>
@@ -661,7 +661,7 @@ function buildStaticSubmitContent(): string {
 function buildStaticHomeContent(): string {
   return `
     <div class="container page pt-0">
-      <section class="section section-card mb-12" data-home-zone="archive-search">
+      <section class="section card card--section section-card mb-12" data-home-zone="archive-search">
         <div class="section-header">
           <h1 class="section-title" data-section-title="Search the Archive"><span class="accent-text">Search</span> the Archive</h1>
         </div>
@@ -681,7 +681,7 @@ function buildStaticHomeContent(): string {
           </div>
         </div>
       </section>
-      <section class="section section-card mb-12" data-home-zone="law-of-day">
+      <section class="section card card--section section-card mb-12" data-home-zone="law-of-day">
         <div class="section-header">
           <h2 class="section-title"><span class="accent-text">Law</span> of the Day</h2>
         </div>
@@ -689,7 +689,7 @@ function buildStaticHomeContent(): string {
           <p>Enable JavaScript for today's rotating law, or browse the full archive now.</p>
         </div>
       </section>
-      <section class="section section-card mb-12" data-home-zone="category-discovery">
+      <section class="section card card--section section-card mb-12" data-home-zone="category-discovery">
         <div class="section-header">
           <h2 class="section-title"><span class="accent-text">Browse</span> by Theme</h2>
         </div>
@@ -698,7 +698,7 @@ function buildStaticHomeContent(): string {
           <a href="/categories" class="btn">See category groups</a>
         </div>
       </section>
-      <section class="section section-card mb-12" data-home-zone="trending-recent">
+      <section class="section card card--section section-card mb-12" data-home-zone="trending-recent">
         <div class="section-header">
           <h2 class="section-title">Trending and Recently Added</h2>
         </div>
@@ -710,7 +710,7 @@ function buildStaticHomeContent(): string {
           </div>
         </div>
       </section>
-      <section class="section section-card mb-12" data-home-zone="tools-submit">
+      <section class="section card card--section section-card mb-12" data-home-zone="tools-submit">
         <div class="section-header">
           <h2 class="section-title"><span class="accent-text">Tools</span> and Submissions</h2>
         </div>
@@ -731,7 +731,7 @@ function buildStaticCalculatorContent(kind: 'sods-law' | 'buttered-toast'): stri
     return `
       <div class="container page calculator">
         <h1 class="page-title mb-4" data-page-title="Sod's Law Calculator"><span class="accent-text">Sod's</span> Law Calculator</h1>
-        <article class="card content-card">
+        <article class="card card--content content-card">
           <header class="card-header content-header">
             <h2 class="card-title"><span class="accent-text">Estimate</span> Your Risk</h2>
             <p class="lead">Model how likely a task is to go wrong using Urgency, Complexity, Importance, Skill, and Frequency.</p>
@@ -758,7 +758,7 @@ function buildStaticCalculatorContent(kind: 'sods-law' | 'buttered-toast'): stri
   return `
     <div class="container page calculator">
       <h1 class="page-title mb-4" data-page-title="Buttered Toast Calculator"><span class="accent-text">Buttered</span> Toast Calculator</h1>
-      <article class="card content-card">
+      <article class="card card--content content-card">
         <header class="card-header content-header">
           <h2 class="card-title"><span class="accent-text">Simulate</span> the Classic Mishap</h2>
           <p class="lead">Explore why toast seems destined to land butter-side down when breakfast is already running late.</p>
@@ -866,7 +866,7 @@ async function main(): Promise<void> {
         <div class="static-content prose mx-auto">
           ${htmlContent}
         </div>
-        <section class="section section-card mb-8" aria-labelledby="category-internal-links-${slug}">
+        <section class="section card card--section section-card mb-8" aria-labelledby="category-internal-links-${slug}">
           <div class="section-header">
             <h2 id="category-internal-links-${slug}" class="section-title"><span class="accent-text">Explore</span> nearby</h2>
           </div>
@@ -967,7 +967,7 @@ async function main(): Promise<void> {
       const cards = group.categories.map(cat => {
       const lawText = cat.law_count === 1 ? 'law' : 'laws';
       return `
-      <article class="category-card" data-category-slug="${cat.slug}">
+      <article class="card card--category category-card category-card--rich" data-category-slug="${cat.slug}">
         <h3 class="category-card-title">${cat.title}</h3>
         <p class="category-card-description">Explore ${cat.law_count} ${lawText} in this category.</p>
         <div class="category-card-footer">

--- a/web/src/components/advanced-search.ts
+++ b/web/src/components/advanced-search.ts
@@ -28,7 +28,7 @@ export interface AdvancedSearchOptions {
 
 export function AdvancedSearch({ onSearch, initialFilters = {} as AdvancedSearchFilters, _testLoadFiltersRef }: AdvancedSearchOptions): HTMLElement {
   const el = document.createElement('section');
-  el.className = 'section section-card mb-12';
+  el.className = 'section card card--section section-card mb-12';
 
   let categories: Array<{ id: number; title: string; slug: string }> = [];
   let selectedCategory = initialFilters.category_id || '';

--- a/web/src/components/buttered-toast-calculator-simple.ts
+++ b/web/src/components/buttered-toast-calculator-simple.ts
@@ -7,7 +7,7 @@ type ToastSimpleSliderKey = 'height' | 'overhang';
 
 export function ButteredToastCalculatorSimple({ onNavigate }: { onNavigate: OnNavigate }) {
   const el = document.createElement('section');
-  el.className = 'section section-card mb-12';
+  el.className = 'section card card--section section-card mb-12';
 
   el.innerHTML = templateHtml;
 

--- a/web/src/components/law-list-section.ts
+++ b/web/src/components/law-list-section.ts
@@ -20,7 +20,7 @@ import type { Law } from '../types/app.d.ts';
  */
 export function createLawListSection({ accentText, remainderText }: { accentText: string; remainderText: string }) {
   const el = document.createElement('div');
-  el.className = 'card law-list-card';
+  el.className = 'card card--law-list law-list-card';
   // Reserve space for law cards to prevent layout shift (using LAW_CARD_MIN_HEIGHT constant)
   el.style.minHeight = `${LAW_CARD_MIN_HEIGHT}px`;
 
@@ -28,7 +28,7 @@ export function createLawListSection({ accentText, remainderText }: { accentText
     <header class="card-header">
       <h3 class="card-title"><span class="accent-text">${accentText}</span>${remainderText}</h3>
     </header>
-    <div class="card-body"></div>
+    <div class="card-body card-body--flush"></div>
   `;
 
   const bodyDiv = el.querySelector('.card-body')!;

--- a/web/src/components/law-of-day.ts
+++ b/web/src/components/law-of-day.ts
@@ -14,7 +14,7 @@ import type { Law, OnNavigate } from '../types/app.d.ts';
 
 export function LawOfTheDay({ law, onNavigate }: { law: Law | null; onNavigate: OnNavigate }) {
   const el = document.createElement('section');
-  el.className = 'section section-card mb-12';
+  el.className = 'section card card--section section-card mb-12';
 
   if (!law) {
     const loading = createLoading({ 

--- a/web/src/components/sod-calculator-simple.ts
+++ b/web/src/components/sod-calculator-simple.ts
@@ -7,7 +7,7 @@ type SliderKey = 'urgency' | 'complexity' | 'importance' | 'skill' | 'frequency'
 
 export function SodCalculatorSimple({ onNavigate }: { onNavigate: OnNavigate }) {
   const el = document.createElement('section');
-  el.className = 'section section-card mb-12';
+  el.className = 'section card card--section section-card mb-12';
 
   el.innerHTML = templateHtml;
 

--- a/web/src/components/submit-law.ts
+++ b/web/src/components/submit-law.ts
@@ -27,7 +27,7 @@ interface SubmitLawPayload extends Record<string, unknown> {
 
 export function SubmitLawSection() {
   const el = document.createElement('section');
-  el.className = 'section section-card mb-12';
+  el.className = 'section card card--section section-card mb-12';
   el.innerHTML = templateHtml;
 
   // Hydrate icons
@@ -183,7 +183,7 @@ export function SubmitLawSection() {
       ? `<a href="/category/${categorySlug}" class="btn outline">Browse your category</a>`
       : '<a href="/categories" class="btn outline">Browse categories</a>';
     nextActions.innerHTML = `
-      <div class="section section-card mt-4">
+      <div class="section card card--section section-card mt-4">
         <div class="section-header">
           <h3 class="section-title"><span class="accent-text">Keep</span> exploring</h3>
         </div>

--- a/web/src/components/trending.ts
+++ b/web/src/components/trending.ts
@@ -16,7 +16,7 @@ import { LAW_CARD_MIN_HEIGHT, WIDGET_CARD_COUNT } from '../utils/constants.ts';
  */
 export function Trending() {
   const el = document.createElement('div');
-  el.className = 'card law-list-card';
+  el.className = 'card card--law-list law-list-card';
   // Reserve space for law cards to prevent layout shift (using LAW_CARD_MIN_HEIGHT constant)
   el.style.minHeight = `${LAW_CARD_MIN_HEIGHT}px`;
 
@@ -24,7 +24,7 @@ export function Trending() {
     <header class="card-header">
       <h3 class="card-title"><span class="accent-text">Trending</span> Now</h3>
     </header>
-    <div class="card-body"></div>
+    <div class="card-body card-body--flush"></div>
   `;
 
   // Template always provides .card-body

--- a/web/src/utils/dom.ts
+++ b/web/src/utils/dom.ts
@@ -29,7 +29,7 @@ export function createErrorState(message = 'Something went wrong. Please try aga
   el.setAttribute('role', 'alert');
   el.setAttribute('aria-live', 'assertive');
   el.innerHTML = `
-    <section class="section section-card">
+    <section class="section card card--section section-card">
       <div class="section-header">
         <h3 class="section-title">
           <span class="icon" data-icon="warning" aria-hidden="true"></span>

--- a/web/src/utils/markdown-content.ts
+++ b/web/src/utils/markdown-content.ts
@@ -70,7 +70,7 @@ export function markdownToHtml(markdownContent: string, options: { lastUpdated?:
   const html = marked.parse(markdownContent, { async: false });
 
   // Wrap in card structure consistent with existing templates
-  let output = '<article class="card content-card">\n';
+  let output = '<article class="card card--content content-card">\n';
 
   // Add last updated date if provided
   if (options.lastUpdated) {
@@ -255,7 +255,7 @@ export function getPageContent(page: ContentPage): string {
     output += `<h1 class="page-title mb-4">${h1Content}</h1>\n`;
 
     // Start the card
-    output += '<article class="card content-card">\n';
+    output += '<article class="card card--content content-card">\n';
 
     // Find the first paragraph after h1
     const firstPMatch = html.substring(afterH1).match(/<p>([\s\S]*?)<\/p>/);
@@ -297,7 +297,7 @@ export function getPageContent(page: ContentPage): string {
     }
   } else {
     // No h1 found, just start card with card-body
-    output += '<article class="card content-card">\n';
+    output += '<article class="card card--content content-card">\n';
     html = '  <div class="card-body">\n' + html;
   }
 

--- a/web/src/views/categories.ts
+++ b/web/src/views/categories.ts
@@ -27,7 +27,7 @@ export function Categories({ onNavigate }: { onNavigate: OnNavigate }): HTMLDivE
     const lawText = lawCount === 1 ? 'law' : 'laws';
 
     return `
-      <article class="category-card" data-category-slug="${category.slug}" tabindex="0" role="link" aria-label="${title} - ${lawCount} ${lawText}">
+      <article class="card card--category category-card category-card--rich" data-category-slug="${category.slug}" tabindex="0" role="link" aria-label="${title} - ${lawCount} ${lawText}">
         <h3 class="category-card-title">${title}</h3>
         <p class="category-card-description">${description}</p>
         <div class="category-card-footer">

--- a/web/src/views/favorites.ts
+++ b/web/src/views/favorites.ts
@@ -27,7 +27,7 @@ export function Favorites({ onNavigate }: { onNavigate: OnNavigate }): HTMLDivEl
   if (!isFavoritesEnabled()) {
     el.innerHTML = `
       <h1 class="page-title mb-4"><span class="accent-text">My</span> Favorites</h1>
-      <div class="card content-card">
+      <div class="card card--empty content-card">
         <header class="card-header text-center">
           <h2 class="card-title"><span class="accent-text">Feature</span> Disabled</h2>
         </header>
@@ -54,7 +54,7 @@ export function Favorites({ onNavigate }: { onNavigate: OnNavigate }): HTMLDivEl
   function renderEmptyState() {
     return `
       <h1 class="page-title mb-4"><span class="accent-text">My</span> Favorites</h1>
-      <div class="card content-card">
+      <div class="card card--empty content-card">
         <header class="card-header text-center">
           <h2 class="card-title"><span class="accent-text">No Favorites</span> Yet</h2>
           <blockquote class="not-found-quote">
@@ -111,7 +111,7 @@ export function Favorites({ onNavigate }: { onNavigate: OnNavigate }): HTMLDivEl
 
     return `
       <h1 class="page-title mb-4"><span class="accent-text">My</span> Favorites</h1>
-      <div class="card">
+      <div class="card card--section">
         <header class="card-header">
           <div class="card-title-row">
             <h2 class="card-title">

--- a/web/src/views/home.ts
+++ b/web/src/views/home.ts
@@ -15,7 +15,7 @@ import { trackProductEvent } from '@utils/metrics.ts';
 import type { CleanableElement, OnNavigate, Law } from '../types/app.d.ts';
 
 const ARCHIVE_SEARCH_HTML = `
-  <section class="section section-card mb-12 browse-cta" data-home-zone="archive-search" aria-labelledby="browse-cta-heading">
+  <section class="section card card--section section-card mb-12 browse-cta" data-home-zone="archive-search" aria-labelledby="browse-cta-heading">
     <div class="section-header">
       <h1 id="browse-cta-heading" class="section-title"><span class="accent-text">Search</span> the Archive</h1>
     </div>
@@ -45,7 +45,7 @@ const ARCHIVE_SEARCH_HTML = `
 `;
 
 const CATEGORY_DISCOVERY_HTML = `
-  <section class="section section-card mb-12" data-home-zone="category-discovery" aria-labelledby="category-discovery-heading">
+  <section class="section card card--section section-card mb-12" data-home-zone="category-discovery" aria-labelledby="category-discovery-heading">
     <div class="section-header">
       <h2 id="category-discovery-heading" class="section-title"><span class="accent-text">Browse</span> by Theme</h2>
     </div>
@@ -63,7 +63,7 @@ const CATEGORY_DISCOVERY_HTML = `
 `;
 
 const SUBMIT_CTA_HTML = `
-  <section class="section section-card mb-12" aria-labelledby="submit-cta-heading">
+  <section class="section card card--section section-card mb-12" aria-labelledby="submit-cta-heading">
     <div class="section-header">
       <h2 id="submit-cta-heading" class="section-title"><span class="accent-text">Submit</span> Your Own</h2>
     </div>
@@ -77,7 +77,7 @@ const SUBMIT_CTA_HTML = `
 `;
 
 const HOME_OVERVIEW_HTML = `
-  <section class="section section-card mb-12">
+  <section class="section card card--section section-card mb-12">
     <div class="section-header">
       <h2 class="section-title"><span class="accent-text">The</span> Science of Murphy's Law</h2>
     </div>

--- a/web/src/views/templates/about.html
+++ b/web/src/views/templates/about.html
@@ -1,4 +1,4 @@
-<article class="card content-card">
+<article class="card card--content content-card">
   <header class="card-header content-header">
     <h1><span class="accent-text">About</span> Murphy's Law Archive</h1>
     <p class="lead">

--- a/web/src/views/templates/browse.html
+++ b/web/src/views/templates/browse.html
@@ -9,7 +9,7 @@
 
 <div class="grid mb-12 section-grid" data-widgets></div>
 
-<div class="card min-h-600" id="browse-all-laws-card">
+<div class="card card--section min-h-600" id="browse-all-laws-card">
   <header class="card-header">
     <h2 class="card-title"><span class="accent-text">All</span> Laws</h2>
     <div id="browse-search-info"></div>

--- a/web/src/views/templates/buttered-toast-calculator.html
+++ b/web/src/views/templates/buttered-toast-calculator.html
@@ -1,6 +1,6 @@
 <h1 class="page-title mb-4"><span class="accent-text">Buttered</span> Toast Landing Calculator</h1>
 
-<div class="card">
+<div class="card card--section">
   <header class="card-header">
     <h2 class="card-title"><span class="accent-text">Calculate</span> Your Toast's Fate</h2>
     <p class="calc-description">Predict whether your toast will land butter-side down based on height, gravity, push force, butter amount, air friction, and toast density.</p>
@@ -39,7 +39,7 @@
       <p id="toast-interpretation" class="calc-interpretation">Adjust the parameters to see the probability.</p>
     </div>
 
-    <section class="section section-card mt-8 mb-8">
+    <section class="section card card--section section-card mt-8 mb-8">
       <div class="section-header">
         <h3 class="section-title"><span class="accent-text">Share</span> Your Results</h3>
       </div>
@@ -49,7 +49,7 @@
       </div>
     </section>
 
-    <section class="section section-card mt-8 mb-8">
+    <section class="section card card--section section-card mt-8 mb-8">
       <div class="section-header">
         <h3 class="section-title"><span class="accent-text">Related</span> Scenarios</h3>
       </div>

--- a/web/src/views/templates/category-detail.html
+++ b/web/src/views/templates/category-detail.html
@@ -2,7 +2,7 @@
 
 <div id="advanced-search-container"></div>
 
-<div class="card min-h-600" id="category-laws-card">
+<div class="card card--section min-h-600" id="category-laws-card">
   <header class="card-header" aria-labelledby="category-detail-title">
     <h2 class="card-title" id="category-detail-title">All Laws</h2>
     <p id="category-description" class="category-detail-description">All laws within this category.</p>

--- a/web/src/views/templates/contact.html
+++ b/web/src/views/templates/contact.html
@@ -1,4 +1,4 @@
-<article class="card content-card">
+<article class="card card--content content-card">
   <header class="card-header content-header">
     <h1><span class="accent-text">Contact</span> Murphy's Law Archive</h1>
     <p class="lead">

--- a/web/src/views/templates/favorites.html
+++ b/web/src/views/templates/favorites.html
@@ -1,6 +1,6 @@
 <div id="favorites-root">
   <h1 class="page-title mb-4" data-page-title="My Favorites"><span class="accent-text">My</span> Favorites</h1>
-  <div class="card content-card">
+  <div class="card card--empty content-card">
     <header class="card-header text-center">
       <h2 class="card-title"><span class="accent-text">No Favorites</span> Yet</h2>
       <blockquote class="not-found-quote">

--- a/web/src/views/templates/law-detail.html
+++ b/web/src/views/templates/law-detail.html
@@ -6,7 +6,7 @@
 
 <div data-law-content hidden>
   <div data-law-card-container></div>
-  <section class="section section-card mb-12" data-law-context aria-labelledby="law-context-heading">
+  <section class="section card card--section section-card mb-12" data-law-context aria-labelledby="law-context-heading">
     <div class="section-header">
       <h3 id="law-context-heading" class="section-title"><span class="accent-text">In</span> context</h3>
     </div>
@@ -16,7 +16,7 @@
       </div>
     </div>
   </section>
-  <section class="section section-card mb-12" data-law-provenance aria-labelledby="law-provenance-heading">
+  <section class="section card card--section section-card mb-12" data-law-provenance aria-labelledby="law-provenance-heading">
     <div class="section-header">
       <h3 id="law-provenance-heading" class="section-title"><span class="accent-text">Source</span> status</h3>
     </div>
@@ -25,13 +25,13 @@
       <p class="small">Know the original source, a better attribution, or a duplicate we should merge? <a href="/contact" data-law-report-link>Report an issue</a>.</p>
     </div>
   </section>
-  <section class="section section-card mb-12" data-law-internal-links-section aria-labelledby="law-internal-links-heading">
+  <section class="section card card--section section-card mb-12" data-law-internal-links-section aria-labelledby="law-internal-links-heading">
     <div class="section-header">
       <h3 id="law-internal-links-heading" class="section-title"><span class="accent-text">Keep</span> exploring</h3>
     </div>
     <div class="section-body" data-law-internal-links></div>
   </section>
-  <section class="section section-card related-laws-section" data-related-laws hidden>
+  <section class="section card card--section section-card related-laws-section" data-related-laws hidden>
     <div class="section-header">
       <h3 class="section-title"><span class="accent-text">Related</span> Laws</h3>
     </div>
@@ -42,7 +42,7 @@
 <div data-not-found hidden></div>
 
 <template data-not-found-template>
-  <div class="card">
+  <div class="card card--section">
     <div class="card-body">
       <div class="empty-state">
         <div class="empty-state-icon">
@@ -71,16 +71,16 @@
 </template>
 
 <template data-law-card-template>
-  <section class="section section-card mb-12" data-law-card-root>
-    <div class="section-header">
-      <h3 class="section-title" data-law-title><span class="visually-hidden">Loading law title...</span></h3>
-    </div>
-    <div class="section-body">
+  <article class="card card--section law-detail-card section-card mb-12" data-law-card-root>
+    <header class="card-header section-header">
+      <h3 class="card-title section-title" data-law-title><span class="visually-hidden">Loading law title...</span></h3>
+    </header>
+    <div class="card-body section-body">
       <blockquote class="lod-quote-large" data-law-text></blockquote>
       <p class="lod-attrib" data-law-attribution hidden></p>
       <div class="small" data-law-submitted hidden></div>
     </div>
-    <div class="section-footer">
+    <footer class="card-footer section-footer">
       <div class="left">
         <div class="vote-group" role="group" aria-label="Vote. Votes are anonymous; no login required." data-tooltip="Upvote or downvote. Votes are anonymous; no login required.">
           <button type="button" class="vote-btn count-up" data-vote="up" data-id="" aria-label="Upvote this law">
@@ -109,6 +109,6 @@
           <span class="btn-text">Browse All Laws</span>
         </button>
       </div>
-    </div>
-  </section>
+    </footer>
+  </article>
 </template>

--- a/web/src/views/templates/not-found.html
+++ b/web/src/views/templates/not-found.html
@@ -1,4 +1,4 @@
-<div class="card content-card">
+<div class="card card--empty content-card">
   <header class="card-header text-center">
     <h1 class="page-title mb-2"><span class="accent-text">Page</span> Not Found</h1>
     <blockquote class="not-found-quote">

--- a/web/src/views/templates/privacy.html
+++ b/web/src/views/templates/privacy.html
@@ -1,4 +1,4 @@
-<article class="card content-card">
+<article class="card card--content content-card">
   <header class="card-header content-header">
     <p class="small">Last updated: {{lastUpdated}}</p>
     <h1><span class="accent-text">Privacy</span> Policy</h1>

--- a/web/src/views/templates/sods-calculator.html
+++ b/web/src/views/templates/sods-calculator.html
@@ -1,6 +1,6 @@
 <h1 class="page-title mb-4"><span class="accent-text">Sod's</span> Law Calculator</h1>
 
-<div class="card">
+<div class="card card--section">
   <header class="card-header">
     <h2 class="card-title"><span class="accent-text">Calculate</span> Your Risk</h2>
     <p class="calc-description">Estimate how likely your task is to go wrong based on urgency, complexity, importance, your skill, and how often you do it.</p>
@@ -38,7 +38,7 @@
       <p id="score-interpretation" class="calc-interpretation">Slide the controls to reveal the likelihood of chaos.</p>
     </div>
 
-    <section class="section section-card mt-8 mb-8">
+    <section class="section card card--section section-card mt-8 mb-8">
       <div class="section-header">
         <h3 class="section-title"><span class="accent-text">Share</span> Your Results</h3>
       </div>
@@ -48,7 +48,7 @@
       </div>
     </section>
 
-    <section class="section section-card mt-8 mb-8">
+    <section class="section card card--section section-card mt-8 mb-8">
       <div class="section-header">
         <h3 class="section-title"><span class="accent-text">Related</span> Scenarios</h3>
       </div>

--- a/web/src/views/templates/terms.html
+++ b/web/src/views/templates/terms.html
@@ -1,4 +1,4 @@
-<article class="card content-card">
+<article class="card card--content content-card">
   <header class="card-header content-header">
     <p class="small">Last updated: {{lastUpdated}}</p>
     <h1><span class="accent-text">Terms</span> of Service</h1>

--- a/web/styles/partials/components.css
+++ b/web/styles/partials/components.css
@@ -79,7 +79,8 @@ button.outline:focus-visible {
 .btn:focus-visible,
 button:focus-visible,
 a.btn:focus-visible,
-.category-card:focus-visible {
+.category-card:focus-visible,
+.card--category:focus-visible {
   outline: 3px solid var(--btn-primary-bg);
   outline-offset: 3px;
 }
@@ -522,6 +523,35 @@ button:disabled {
   border: 1px solid var(--border);
   border-radius: .75rem;
   background: color-mix(in oklab, var(--bg) 96%, white 4%);
+}
+
+.card--section,
+.section-card {
+  border: 2px solid var(--border);
+  border-radius: .75rem;
+  background: color-mix(in oklab, var(--bg) 98%, white 2%);
+  box-shadow: 0 20px 40px var(--shadow-light), 0 2px 6px var(--shadow-light);
+}
+
+.card--content,
+.content-card {
+  border: 1px solid color-mix(in oklab, var(--border) 80%, white 20%);
+  box-shadow: 0 18px 50px color-mix(in oklab, var(--shadow-light) 80%, transparent 20%),
+    0 6px 20px color-mix(in oklab, var(--shadow-light) 60%, transparent 40%);
+  background: color-mix(in oklab, var(--bg) 97%, white 3%);
+}
+
+.card--law-list,
+.law-list-card {
+  overflow: hidden;
+}
+
+.card--empty {
+  text-align: center;
+}
+
+.card-body--flush {
+  padding: 0;
 }
 
 .card-title {
@@ -1349,7 +1379,7 @@ kbd {
 }
 
 /* Category Card */
-.category-card {
+.category-card--rich {
   display: flex;
   flex-direction: column;
   padding: 1.25rem;
@@ -1360,13 +1390,13 @@ kbd {
   transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
 }
 
-.category-card:hover {
+.category-card--rich:hover {
   border-color: var(--btn-primary-bg);
   box-shadow: 0 4px 12px var(--shadow-light), 0 0 0 1px color-mix(in oklab, var(--btn-primary-bg) 20%, transparent 80%);
   transform: translateY(-2px);
 }
 
-.category-card:active {
+.category-card--rich:active {
   transform: translateY(0);
 }
 
@@ -1422,8 +1452,8 @@ kbd {
   transition: opacity 0.15s ease, transform 0.15s ease;
 }
 
-.category-card:hover .category-card-arrow,
-.category-card:focus-visible .category-card-arrow {
+.category-card--rich:hover .category-card-arrow,
+.category-card--rich:focus-visible .category-card-arrow {
   opacity: 1;
   transform: translateX(0);
 }
@@ -1436,12 +1466,12 @@ kbd {
 
 /* Dark mode adjustments for category cards */
 @media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) .category-card {
+  :root:not([data-theme="light"]) .category-card--rich {
     background: var(--dark-bg-secondary);
     border-color: var(--dark-border);
   }
 
-  :root:not([data-theme="light"]) .category-card:hover {
+  :root:not([data-theme="light"]) .category-card--rich:hover {
     border-color: var(--btn-primary-bg);
     background: color-mix(in oklab, var(--dark-bg-secondary) 95%, var(--btn-primary-bg) 5%);
   }
@@ -1451,12 +1481,12 @@ kbd {
   }
 }
 
-:root[data-theme="dark"] .category-card {
+:root[data-theme="dark"] .category-card--rich {
   background: var(--dark-bg-secondary);
   border-color: var(--dark-border);
 }
 
-:root[data-theme="dark"] .category-card:hover {
+:root[data-theme="dark"] .category-card--rich:hover {
   border-color: var(--btn-primary-bg);
   background: color-mix(in oklab, var(--dark-bg-secondary) 95%, var(--btn-primary-bg) 5%);
 }
@@ -1472,7 +1502,7 @@ kbd {
     gap: 1rem;
   }
 
-  .category-card {
+  .category-card--rich {
     padding: 1rem;
   }
 

--- a/web/styles/partials/print.css
+++ b/web/styles/partials/print.css
@@ -225,7 +225,9 @@
     display: block;
   }
 
-  .category-card {
+  .card--category,
+  .category-card--rich,
+  .category-card--compact {
     border: 1px solid #ccc !important;
     margin-bottom: 0.5rem;
     break-inside: avoid;

--- a/web/styles/partials/sections.css
+++ b/web/styles/partials/sections.css
@@ -104,7 +104,7 @@
   margin-top: 1.5rem;
 }
 
-.category-card {
+.category-card--compact {
   padding: 1.25rem;
   background: color-mix(in oklab, var(--bg) 96%, var(--fg) 4%);
   border: 1px solid var(--border);
@@ -120,14 +120,14 @@
   overflow: hidden;
 }
 
-.category-card:hover {
+.category-card--compact:hover {
   background: color-mix(in oklab, var(--bg) 94%, var(--primary) 6%);
   transform: translateY(-3px);
   border-color: var(--primary);
   box-shadow: 0 8px 16px var(--shadow-light);
 }
 
-.category-card .category-title {
+.category-card--compact .category-title {
   margin: 0;
   font-size: 1.1rem;
   font-weight: 600;
@@ -140,13 +140,13 @@
   overflow: hidden;
 }
 
-.category-card .category-count {
+.category-card--compact .category-count {
   font-size: 0.8rem;
   color: var(--muted-fg);
   margin-top: 0.5rem;
 }
 
-.category-card .category-description {
+.category-card--compact .category-description {
   font-size: 0.875rem;
   color: var(--muted-fg);
   margin: 0.5rem 0 1rem;
@@ -167,14 +167,6 @@
   #category-laws-card .category-detail-description {
     font-size: 1.05rem;
   }
-}
-
-/* Law of the Day widget (scoped) */
-.section-card {
-  border: 2px solid var(--border);
-  border-radius: .75rem;
-  background: color-mix(in oklab, var(--bg) 98%, white 2%);
-  box-shadow: 0 20px 40px var(--shadow-light), 0 2px 6px var(--shadow-light);
 }
 
 .section-header {
@@ -230,13 +222,6 @@
 .content-page {
   padding-top: 3rem;
   padding-bottom: 4rem;
-}
-
-.content-card {
-  border: 1px solid color-mix(in oklab, var(--border) 80%, white 20%);
-  box-shadow: 0 18px 50px color-mix(in oklab, var(--shadow-light) 80%, transparent 20%),
-    0 6px 20px color-mix(in oklab, var(--shadow-light) 60%, transparent 40%);
-  background: color-mix(in oklab, var(--bg) 97%, white 3%);
 }
 
 /* Content card with new card structure */
@@ -1149,18 +1134,21 @@
 }
 
 /* Mini Law Cards (for Top Voted, Trending, Recently Added) */
-.card .card-title {
+.card--law-list .card-title,
+.law-list-card .card-title {
   padding: 0 1rem 0.75rem;
   margin: 0;
   border-bottom: 1px solid var(--border);
 }
 
-.card.law-list-card .card-title {
+.card--law-list .card-header .card-title,
+.law-list-card .card-header .card-title {
   padding: 0;
   border-bottom: none;
 }
 
-.card.law-list-card .card-body {
+.card--law-list .card-body,
+.law-list-card .card-body {
   padding: 0;
 }
 

--- a/web/styles/partials/theme.css
+++ b/web/styles/partials/theme.css
@@ -529,7 +529,9 @@
   /* Enhanced card borders and remove subtle background variations */
   .card,
   .section-card,
-  .category-card {
+  .card--category,
+  .category-card--rich,
+  .category-card--compact {
     border-width: 2px;
     border-color: var(--fg);
     background: var(--bg);
@@ -578,7 +580,9 @@
 
   :root:not([data-theme="light"]) .card,
   :root:not([data-theme="light"]) .section-card,
-  :root:not([data-theme="light"]) .category-card {
+  :root:not([data-theme="light"]) .card--category,
+  .category-card--rich,
+  .category-card--compact {
     border-color: var(--fg);
   }
 
@@ -606,7 +610,9 @@
 
   :root[data-theme="dark"] .card,
   :root[data-theme="dark"] .section-card,
-  :root[data-theme="dark"] .category-card {
+  :root[data-theme="dark"] .card--category,
+  .category-card--rich,
+  .category-card--compact {
     border-color: var(--fg);
   }
 
@@ -642,7 +648,9 @@
 
 :root[data-contrast="more"] .card,
 :root[data-contrast="more"] .section-card,
-:root[data-contrast="more"] .category-card {
+:root[data-contrast="more"] .card--category,
+  .category-card--rich,
+  .category-card--compact {
   border-width: 2px;
   border-color: var(--fg);
   background: var(--bg);
@@ -694,7 +702,9 @@
 :root[data-contrast="more"][data-theme="dark"] .category-card,
 :root[data-contrast="more"]:not([data-theme="light"]) .card,
 :root[data-contrast="more"]:not([data-theme="light"]) .section-card,
-:root[data-contrast="more"]:not([data-theme="light"]) .category-card {
+:root[data-contrast="more"]:not([data-theme="light"]) .card--category,
+  .category-card--rich,
+  .category-card--compact {
   border-color: var(--fg);
 }
 

--- a/web/tests/categories.test.ts
+++ b/web/tests/categories.test.ts
@@ -215,6 +215,9 @@ describe('Categories view', () => {
     expect(card).toBeTruthy();
     expect(card!.getAttribute('tabindex')).toBe('0');
     expect(card!.getAttribute('role')).toBe('link');
+    expect(card!.classList.contains('card')).toBe(true);
+    expect(card!.classList.contains('card--category')).toBe(true);
+    expect(card!.classList.contains('category-card--rich')).toBe(true);
     expect(card!.getAttribute('aria-label')).toContain('laws');
   });
 

--- a/web/tests/design-token-leftovers.test.ts
+++ b/web/tests/design-token-leftovers.test.ts
@@ -30,6 +30,18 @@ describe('design-token leftovers', () => {
     expect(localThis.content).not.toContain('--primary: #4f46e5;');
   });
 
+  it('defines canonical card variants with compatibility aliases', () => {
+    const components = readWebFile('styles/partials/components.css');
+    expect(components).toContain('.card--section');
+    expect(components).toContain('.section-card');
+    expect(components).toContain('.card--content');
+    expect(components).toContain('.content-card');
+    expect(components).toContain('.card--law-list');
+    expect(components).toContain('.law-list-card');
+    expect(components).toContain('.card--empty');
+    expect(components).toContain('.card-body--flush');
+  });
+
   it('does not keep stale implementation colors outside variables.css', () => {
     const localThis: FileScanLocalThis = {};
     localThis.root = root;

--- a/web/tests/law-detail.test.ts
+++ b/web/tests/law-detail.test.ts
@@ -54,6 +54,7 @@ describe('LawDetail view', () => {
     globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => law });
     const el = LawDetail({ lawId: '1', onNavigate: () => { } });
     await vi.waitFor(() => expect(el.textContent).toMatch(/A Law/), { timeout: 500 });
+    expect(el.querySelector('[data-law-card-root]')?.className).toContain('card--section law-detail-card');
     expect(el.querySelector('[data-upvote-count]')?.textContent).toBe('1');
   });
 

--- a/web/tests/law-list-section.test.ts
+++ b/web/tests/law-list-section.test.ts
@@ -11,6 +11,7 @@ describe('LawListSection component', () => {
     expect(el.tagName).toBe('DIV');
     expect(el.classList.contains('card')).toBe(true);
     expect(el.classList.contains('law-list-card')).toBe(true);
+    expect(el.classList.contains('card--law-list')).toBe(true);
   });
 
   it('renders title with accent and remainder text', () => {
@@ -18,6 +19,8 @@ describe('LawListSection component', () => {
       accentText: 'Top',
       remainderText: ' Voted'
     });
+
+    expect(el.querySelector('.card-body')?.classList.contains('card-body--flush')).toBe(true);
 
     const title = el.querySelector('.card-title');
     expect(title).toBeTruthy();

--- a/web/tests/markdown-content.test.ts
+++ b/web/tests/markdown-content.test.ts
@@ -10,7 +10,7 @@ describe('markdown-content.js', () => {
       const markdown = '# Hello World\nThis is a test.';
       const html = markdownToHtml(markdown);
       
-      expect(html).toContain('<article class="card content-card">');
+      expect(html).toContain('<article class="card card--content content-card">');
       expect(html).toContain('<h1>Hello World</h1>');
       expect(html).toContain('<p>This is a test.</p>');
       expect(html).toContain('</article>');
@@ -42,7 +42,7 @@ describe('markdown-content.js', () => {
     it('returns HTML content for about page', () => {
       const html = getPageContent('about');
 
-      expect(html).toContain('<article class="card content-card">');
+      expect(html).toContain('<article class="card card--content content-card">');
       expect(html).toContain('<header class="card-header content-header">');
       expect(html).toContain('About');
       expect(html).toContain('Murphy');
@@ -68,20 +68,20 @@ describe('markdown-content.js', () => {
     it('returns HTML content for examples page (L199)', () => {
       const html = getPageContent('examples');
       expect(html).toBeDefined();
-      expect(html).toContain('<article class="card content-card">');
+      expect(html).toContain('<article class="card card--content content-card">');
     });
 
     it('returns HTML content for why-murphys-law-feels-true page', () => {
       const html = getPageContent('why-murphys-law-feels-true');
       expect(html).toBeDefined();
-      expect(html).toContain('<article class="card content-card">');
+      expect(html).toContain('<article class="card card--content content-card">');
       expect(html).toContain('Universe');
     });
 
     it('returns HTML content for murphys-law-project-management page', () => {
       const html = getPageContent('murphys-law-project-management');
       expect(html).toBeDefined();
-      expect(html).toContain('<article class="card content-card">');
+      expect(html).toContain('<article class="card card--content content-card">');
       expect(html).toContain('Survival Guide');
     });
 
@@ -312,7 +312,7 @@ describe('markdown-content.js', () => {
     it('handles case where h1Match is null', () => {
       vi.spyOn(marked, 'parse').mockReturnValueOnce('<h2>No H1</h2><p>Content</p>');
       const html = getPageContent('about');
-      expect(html).toContain('<article class="card content-card">');
+      expect(html).toContain('<article class="card card--content content-card">');
       vi.restoreAllMocks();
     });
 

--- a/web/tests/ssg.test.ts
+++ b/web/tests/ssg.test.ts
@@ -101,7 +101,7 @@ describe('SSG Utilities', () => {
       const html = '<h1>Title</h1><p>Content</p>';
       const result = wrapInCardStructure(html);
       
-      expect(result).toContain('<article class="card content-card">');
+      expect(result).toContain('<article class="card card--content content-card">');
       expect(result).toContain('</article>');
     });
 
@@ -123,7 +123,7 @@ describe('SSG Utilities', () => {
       const html = '<p>Just some content without a heading</p>';
       const result = wrapInCardStructure(html);
       
-      expect(result).toContain('<article class="card content-card">');
+      expect(result).toContain('<article class="card card--content content-card">');
       expect(result).toContain('<div class="card-body">');
       expect(result).toContain('Just some content without a heading');
       expect(result).not.toContain('<header');
@@ -228,6 +228,7 @@ describe('SSG Static Route Content', () => {
     expect(html).toMatch(/Source status/i);
     expect(html).toMatch(/In context/i);
     expect(html).toMatch(/Related laws/i);
+    expect(html).toContain('card--section law-detail-card');
     expect(html).toContain('/category/murphys-technology-laws');
     expect(html).toContain('/examples/tech');
     expect(html).toContain('Technology hub');


### PR DESCRIPTION
## Summary
- Add canonical card variants and document the card system in `web/DESIGN.md`.
- Migrate card-like web markup to explicit section, content, law-list, category, and empty-state variants while keeping legacy aliases.
- Scope card CSS to reduce broad selector conflicts and align runtime/SSG card output.

## Test plan
- [x] `npm run ci:web`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ravidorr/murphys-laws/120)
<!-- Reviewable:end -->
