### PR TITLE
chore: fix PostCSS audit advisory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Forced PostCSS resolution to `8.5.12` so Vite and Stylelint no longer pull in
+  the vulnerable `postcss <8.5.10` dev-tooling copy flagged by `npm audit`.
+  Root bumped to `2.5.3`.
+
 ### Added
 - Growth follow-up surfaces for the archive: new internal-link modules connect
   laws, categories, calculators, hubs, and examples; calculators now use stable

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murphys-laws-monorepo",
-      "version": "2.5.2",
+      "version": "2.5.3",
       "license": "CC0-1.0",
       "workspaces": [
         "backend",
@@ -12407,9 +12407,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "Murphy's Laws - Monorepo for Web, iOS, and Android apps",
   "private": true,
   "workspaces": [
@@ -70,6 +70,7 @@
     "tsx": "^4.20.3"
   },
   "overrides": {
+    "postcss": "8.5.12",
     "serialize-javascript": "7.0.5",
     "html-encoding-sniffer": "4.0.0",
     "workbox-build": {


### PR DESCRIPTION
## Summary
- Force transitive PostCSS consumers to resolve to `8.5.12` via the root npm override.
- Patch-bump the root package to `2.5.3` and document the audit fix in `CHANGELOG.md`.

## Test plan
- `npm audit`
- `npm ls postcss`
- Pre-commit hooks: `check:versions`, backend typecheck/lint/build/test coverage, web typecheck/lint/lint:css/lint:html/test coverage/E2E/coverage check

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ravidorr/murphys-laws/121)
<!-- Reviewable:end -->
