### PR TITLE
fix(web): align law-list card surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Law-list cards now use the same elevated card shadow, border, and row padding
+  scale as other archive cards, so Browse widgets no longer look visually flatter
+  than neighboring card surfaces. Web bumped to `3.3.3`; root to `2.5.4`.
 - Forced PostCSS resolution to `8.5.12` so Vite and Stylelint no longer pull in
   the vulnerable `postcss <8.5.10` dev-tooling copy flagged by `npm audit`.
   Root bumped to `2.5.3`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murphys-laws-monorepo",
-      "version": "2.5.3",
+      "version": "2.5.4",
       "license": "CC0-1.0",
       "workspaces": [
         "backend",
@@ -16252,7 +16252,7 @@
     },
     "web": {
       "name": "murphys-laws-web",
-      "version": "3.3.2",
+      "version": "3.3.3",
       "license": "CC0-1.0",
       "dependencies": {
         "@sentry/browser": "^10.25.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "Murphy's Laws - Monorepo for Web, iOS, and Android apps",
   "private": true,
   "workspaces": [

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-web",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "Murphy's Laws Web Application",
   "type": "module",
   "scripts": {

--- a/web/styles/partials/components.css
+++ b/web/styles/partials/components.css
@@ -543,6 +543,10 @@ button:disabled {
 
 .card--law-list,
 .law-list-card {
+  border: 2px solid var(--border);
+  border-radius: .75rem;
+  background: color-mix(in oklab, var(--bg) 98%, white 2%);
+  box-shadow: 0 20px 40px var(--shadow-light), 0 2px 6px var(--shadow-light);
   overflow: hidden;
 }
 

--- a/web/styles/partials/sections.css
+++ b/web/styles/partials/sections.css
@@ -1163,6 +1163,11 @@
   transition: background-color 0.15s ease;
 }
 
+.card--law-list .law-card-mini,
+.law-list-card .law-card-mini {
+  padding: 1rem 1.25rem;
+}
+
 .law-card-mini:last-child {
   border-bottom: none;
 }

--- a/web/tests/design-token-leftovers.test.ts
+++ b/web/tests/design-token-leftovers.test.ts
@@ -42,6 +42,21 @@ describe('design-token leftovers', () => {
     expect(components).toContain('.card-body--flush');
   });
 
+  it('keeps law-list cards visually aligned with section card surfaces', () => {
+    const localThis: FileScanLocalThis = {};
+    localThis.content = readWebFile('styles/partials/components.css');
+
+    expect(localThis.content).toMatch(/\.card--law-list,\n\.law-list-card\s*\{[^}]*box-shadow:/);
+    expect(localThis.content).toMatch(/\.card--law-list,\n\.law-list-card\s*\{[^}]*border:\s*2px solid var\(--border\);/);
+  });
+
+  it('keeps law-list row padding on the shared card spacing scale', () => {
+    const localThis: FileScanLocalThis = {};
+    localThis.content = readWebFile('styles/partials/sections.css');
+
+    expect(localThis.content).toMatch(/\.card--law-list \.law-card-mini,\n\.law-list-card \.law-card-mini\s*\{[^}]*padding:\s*1rem 1\.25rem;/);
+  });
+
   it('does not keep stale implementation colors outside variables.css', () => {
     const localThis: FileScanLocalThis = {};
     localThis.root = root;


### PR DESCRIPTION
## Summary
- Align law-list widgets with the elevated archive card surface used elsewhere.
- Normalize law-row padding in law-list cards and add regression coverage for the card surface contract.
- Patch-bump root to `2.5.4` and web to `3.3.3`, with a `CHANGELOG.md` entry.

## Test plan
- `npm --prefix web test -- tests/design-token-leftovers.test.ts tests/law-list-section.test.ts tests/recently-added.test.ts tests/trending.test.ts`
- `npm --prefix web run lint:css`
- Pre-commit hooks: `check:versions`, backend typecheck/lint/build/test coverage, web typecheck/lint/lint:css/lint:html/test coverage/E2E/coverage check

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ravidorr/murphys-laws/122)
<!-- Reviewable:end -->
