### PR TITLE
docs(web): document law-list card surface behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Work Sans variable font bundled in the Android app for visual parity with web. [android/app/src/main/res/font/work_sans_variable.ttf](android/app/src/main/res/font/work_sans_variable.ttf) (~360 KB, single VF covers all weights via the `wght` axis), wrapped by a hand-authored `WorkSans` `FontFamily` in [android/app/src/main/java/com/murphyslaws/ui/theme/WorkSans.kt](android/app/src/main/java/com/murphyslaws/ui/theme/WorkSans.kt). The FontFamily registers the variable font at four weight slots (Normal 400, Medium 500, SemiBold 600, Bold 700) with `FontVariation.Settings(FontVariation.weight(...))` so Compose's typography system resolves `.weight(...)` requests to the correct axis position. Requires API 26+, which matches the app's `minSdk`. [shared/design-tokens/export-android-tokens.ts](shared/design-tokens/export-android-tokens.ts) now emits `fontFamily = WorkSans` for every `DS.Typography.<level>`, replacing the `FontFamily.Default` (Roboto) placeholder from PR Android-1. PR Android-3 (final phase) of the design-tokens-mobile rollout. Bundling a new font is user-visible, so Android app bumped MINOR to `1.1.0` / versionCode `4`; root to `2.4.23`.
 
 ### Changed
+- Documented that law-list card widgets share the elevated section-card surface
+  while keeping flush bodies for full-width row dividers. Root bumped to `2.5.5`.
 - Web card surfaces now use a canonical card shell and variant class system
   across section widgets, law-list widgets, category cards, content pages,
   empty states, and law detail runtime/SSG output. Legacy class names remain as

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murphys-laws-monorepo",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "license": "CC0-1.0",
       "workspaces": [
         "backend",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "description": "Murphy's Laws - Monorepo for Web, iOS, and Android apps",
   "private": true,
   "workspaces": [

--- a/web/DESIGN.md
+++ b/web/DESIGN.md
@@ -382,7 +382,9 @@ Use a variant class with `card` so the surface intent is explicit:
   Legacy alias: `content-card`.
 - `card--law-list`: stacked law-list widgets such as Top Voted, Trending Now,
   and Recently Added. Legacy alias: `law-list-card`. The child rows remain
-  `law-card-mini` and are not standalone card shells.
+  `law-card-mini` and are not standalone card shells. Law-list widgets use the
+  same elevated surface treatment as section cards while keeping their body
+  flush for full-width row dividers.
 - `card--category`: category tiles. Use `category-card--rich` for the current
   grouped category cards and `category-card--compact` only for older compact
   directory tiles. Legacy alias: `category-card`.


### PR DESCRIPTION
## Summary
- Document that law-list widgets share the elevated section-card surface treatment.
- Clarify that law-list bodies remain flush to preserve full-width row dividers.
- Patch-bump root to `2.5.5` and record the documentation update in `CHANGELOG.md`.

## Test plan
- `npm run lint:md -- web/DESIGN.md CHANGELOG.md`
- `npm run design:check`
- Pre-commit hooks: `check:versions`, backend typecheck/lint/build/test coverage, web typecheck/lint/lint:css/lint:html/test coverage/E2E/coverage check

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ravidorr/murphys-laws/123)
<!-- Reviewable:end -->
