### PR TITLE
chore(android): refresh Gradle and SDK dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Work Sans variable font bundled in the Android app for visual parity with web. [android/app/src/main/res/font/work_sans_variable.ttf](android/app/src/main/res/font/work_sans_variable.ttf) (~360 KB, single VF covers all weights via the `wght` axis), wrapped by a hand-authored `WorkSans` `FontFamily` in [android/app/src/main/java/com/murphyslaws/ui/theme/WorkSans.kt](android/app/src/main/java/com/murphyslaws/ui/theme/WorkSans.kt). The FontFamily registers the variable font at four weight slots (Normal 400, Medium 500, SemiBold 600, Bold 700) with `FontVariation.Settings(FontVariation.weight(...))` so Compose's typography system resolves `.weight(...)` requests to the correct axis position. Requires API 26+, which matches the app's `minSdk`. [shared/design-tokens/export-android-tokens.ts](shared/design-tokens/export-android-tokens.ts) now emits `fontFamily = WorkSans` for every `DS.Typography.<level>`, replacing the `FontFamily.Default` (Roboto) placeholder from PR Android-1. PR Android-3 (final phase) of the design-tokens-mobile rollout. Bundling a new font is user-visible, so Android app bumped MINOR to `1.1.0` / versionCode `4`; root to `2.4.23`.
 
 ### Changed
+- Android now targets SDK 37, uses the latest Gradle, Kotlin, Compose, Hilt,
+  Navigation, serialization, and test dependencies, and keeps resource
+  packaging excludes aligned with the shipped license files. Android app
+  bumped to `1.2.2` / versionCode `9`; root to `2.5.6`.
 - Documented that law-list card widgets share the elevated section-card surface
   while keeping flush bodies for full-width row dividers. Root bumped to `2.5.5`.
 - Web card surfaces now use a canonical card shell and variant class system

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("com.android.application")
-    id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.compose")
     id("com.google.dagger.hilt.android")
     id("com.google.devtools.ksp")
@@ -11,14 +10,14 @@ plugins {
 
 android {
     namespace = "com.murphyslaws"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "com.murphyslaws"
         minSdk = 26
-        targetSdk = 36
-        versionCode = 8
-        versionName = "1.2.1"
+        targetSdk = 37
+        versionCode = 9
+        versionName = "1.2.2"
 
         testInstrumentationRunner = "com.murphyslaws.CustomTestRunner"
         vectorDrawables {
@@ -40,9 +39,6 @@ android {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
-    kotlinOptions {
-        jvmTarget = "11"
-    }
     buildFeatures {
         compose = true
     }
@@ -52,6 +48,12 @@ android {
             excludes += "META-INF/LICENSE.md"
             excludes += "META-INF/LICENSE-notice.md"
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11)
     }
 }
 
@@ -65,7 +67,7 @@ tasks.register<Copy>("copySharedContent") {
 
 // Regenerate Android design tokens from shared/DESIGN.md.
 // Outputs (Tokens.kt, colors.xml, values-night/colors.xml, dimens.xml) are
-// gitignored; this task ensures they exist and are fresh on every build.
+// gitignore: this task ensures they exist and are up to date on every build.
 // Skipped automatically if Node/npm aren't on PATH (the build will then fail
 // at the Kotlin compile step with a clear "missing Tokens.kt" error, which
 // points at this task).
@@ -92,7 +94,7 @@ tasks.register<Exec>("exportDesignTokens") {
     }
 }
 
-// Run before processing resources
+// Run before processing resource
 tasks.named("preBuild") {
     dependsOn("copySharedContent")
     dependsOn("exportDesignTokens")
@@ -100,10 +102,10 @@ tasks.named("preBuild") {
 
 
 dependencies {
-    implementation("androidx.core:core-ktx:1.17.0")
+    implementation("androidx.core:core-ktx:1.18.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.10.0")
-    implementation("androidx.activity:activity-compose:1.12.1")
-    implementation(platform("androidx.compose:compose-bom:2025.12.00"))
+    implementation("androidx.activity:activity-compose:1.13.0")
+    implementation(platform("androidx.compose:compose-bom:2026.05.00"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
@@ -111,13 +113,13 @@ dependencies {
     implementation("androidx.compose.material:material-icons-extended")
 
     // Hilt
-    implementation("com.google.dagger:hilt-android:2.57.2")
-    ksp("com.google.dagger:hilt-android-compiler:2.57.2")
+    implementation("com.google.dagger:hilt-android:2.59.2")
+    ksp("com.google.dagger:hilt-android-compiler:2.59.2")
     implementation("androidx.hilt:hilt-navigation-compose:1.3.0")
     implementation("androidx.hilt:hilt-lifecycle-viewmodel-compose:1.3.0")
 
     // Navigation
-    implementation("androidx.navigation:navigation-compose:2.9.6")
+    implementation("androidx.navigation:navigation-compose:2.9.8")
 
     // Retrofit & Moshi
     implementation("com.squareup.retrofit2:retrofit:3.0.0")
@@ -126,7 +128,7 @@ dependencies {
     implementation("com.squareup.okhttp3:logging-interceptor:5.3.2")
 
     // Kotlinx Serialization
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
 
     // Pendo SDK
     implementation("sdk.pendo.io:pendoIO:3.9.+") {
@@ -135,8 +137,8 @@ dependencies {
 
     // Testing - Unit Tests
     testImplementation("junit:junit:4.13.2")
-    testImplementation("io.mockk:mockk:1.14.7")
-    testImplementation("org.mockito:mockito-core:5.20.0")
+    testImplementation("io.mockk:mockk:1.14.9")
+    testImplementation("org.mockito:mockito-core:5.23.0")
     testImplementation("org.mockito:mockito-inline:5.2.0")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
     testImplementation("app.cash.turbine:turbine:1.2.1")
@@ -145,20 +147,20 @@ dependencies {
     // Testing - Android/Instrumented Tests
     androidTestImplementation("androidx.test.ext:junit:1.3.0")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.7.0")
-    androidTestImplementation("io.mockk:mockk-android:1.14.7")
+    androidTestImplementation("io.mockk:mockk-android:1.14.9")
     androidTestImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
     
     // Testing - Compose UI
-    androidTestImplementation(platform("androidx.compose:compose-bom:2025.12.00"))
+    androidTestImplementation(platform("androidx.compose:compose-bom:2026.05.00"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
     
     // Testing - Hilt
-    testImplementation("com.google.dagger:hilt-android-testing:2.57.2")
-    kspTest("com.google.dagger:hilt-android-compiler:2.57.2")
-    androidTestImplementation("com.google.dagger:hilt-android-testing:2.57.2")
-    kspAndroidTest("com.google.dagger:hilt-android-compiler:2.57.2")
+    testImplementation("com.google.dagger:hilt-android-testing:2.59.2")
+    kspTest("com.google.dagger:hilt-android-compiler:2.59.2")
+    androidTestImplementation("com.google.dagger:hilt-android-testing:2.59.2")
+    kspAndroidTest("com.google.dagger:hilt-android-compiler:2.59.2")
 }
 
 // JaCoCo Configuration
@@ -199,11 +201,11 @@ tasks.register<JacocoReport>("jacocoTestReport") {
         // Navigation
         "**/presentation/navigation/*",
         // Android integration methods in util (require Context, tested via instrumented tests)
-        "**/util/SocialShareHelper\$shareToSocial*",
-        "**/util/SocialShareHelper\$openUrl*"
+        $$"**/util/SocialShareHelper$shareToSocial*",
+        $$"**/util/SocialShareHelper$openUrl*"
     )
     
-    val debugTree = fileTree("${project.buildDir}/tmp/kotlin-classes/debug") {
+    val debugTree = fileTree(project.layout.buildDirectory.dir("tmp/kotlin-classes/debug")) {
         exclude(fileFilter)
     }
     
@@ -211,7 +213,7 @@ tasks.register<JacocoReport>("jacocoTestReport") {
     
     sourceDirectories.setFrom(files(mainSrc))
     classDirectories.setFrom(files(debugTree))
-    executionData.setFrom(fileTree(project.buildDir) {
+    executionData.setFrom(fileTree(project.layout.buildDirectory) {
         include("outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec")
     })
 }

--- a/android/app/src/androidTest/java/com/murphyslaws/presentation/home/FakeLawRepository.kt
+++ b/android/app/src/androidTest/java/com/murphyslaws/presentation/home/FakeLawRepository.kt
@@ -36,25 +36,25 @@ class FakeLawRepository : LawRepository {
         }
     }
     
-    override suspend fun searchLaws(query: String, limit: Int, offset: Int): Result<List<Law>> {
+    override suspend fun searchLaws(): Result<List<Law>> {
         return Result.success(emptyList()) // Return empty list for tests
     }
     
-    override suspend fun voteLaw(lawId: Int, voteType: String): Result<VoteResponse> {
+    override suspend fun voteLaw(): Result<VoteResponse> {
         // For tests, just return a success response
         return Result.success(VoteResponse(upvotes = 43, downvotes = 7))
     }
     
-    override suspend fun unvoteLaw(lawId: Int): Result<VoteResponse> {
+    override suspend fun unvoteLaw(): Result<VoteResponse> {
         // For tests, just return a success response
         return Result.success(VoteResponse(upvotes = 42, downvotes = 7))
     }
 
-    override suspend fun getLaws(limit: Int, offset: Int): Result<List<Law>> {
-        return searchLaws("", limit, offset)
+    override suspend fun getLaws(): Result<List<Law>> {
+        return searchLaws()
     }
 
-    override suspend fun submitLaw(text: String, title: String?, name: String?, email: String?): Result<Unit> {
+    override suspend fun submitLaw(): Result<Unit> {
         return Result.success(Unit)
     }
 }

--- a/android/app/src/main/java/com/murphyslaws/presentation/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/murphyslaws/presentation/home/HomeScreen.kt
@@ -227,7 +227,7 @@ fun HomeScreen(
                                 horizontalArrangement = Arrangement.spacedBy(DS.Radius.md)
                             ) {
                                 val context = androidx.compose.ui.platform.LocalContext.current
-                                // Third-party brand colours are shared DS tokens.
+                                // Third-party brand colors are shared DS tokens.
                                 val socialButtons = listOf(
                                     Triple(SocialIcons.X, DS.Color.brandSocialX, com.murphyslaws.util.SocialPlatform.X),
                                     Triple(SocialIcons.Facebook, DS.Color.brandSocialFacebook, com.murphyslaws.util.SocialPlatform.FACEBOOK),

--- a/android/app/src/main/java/com/murphyslaws/presentation/lawdetail/LawDetailScreen.kt
+++ b/android/app/src/main/java/com/murphyslaws/presentation/lawdetail/LawDetailScreen.kt
@@ -142,7 +142,7 @@ fun LawDetailScreen(
                             horizontalArrangement = Arrangement.spacedBy(DS.Radius.md)
                         ) {
                             val context = LocalContext.current
-                            // Third-party brand colours are shared DS tokens.
+                            // Third-party brand colors are shared DS tokens.
                             val socialButtons = listOf(
                                 Triple(SocialIcons.X, DS.Color.brandSocialX, com.murphyslaws.util.SocialPlatform.X),
                                 Triple(SocialIcons.Facebook, DS.Color.brandSocialFacebook, com.murphyslaws.util.SocialPlatform.FACEBOOK),

--- a/android/app/src/main/java/com/murphyslaws/ui/theme/Type.kt
+++ b/android/app/src/main/java/com/murphyslaws/ui/theme/Type.kt
@@ -6,7 +6,7 @@ import androidx.compose.material3.Typography
  * Material 3 Typography mapped from shared/DESIGN.md typography levels via
  * the generated DS.Typography namespace.
  *
- * DESIGN.md exposes 9 semantic levels (display, h1..h4, body-lg..body-sm,
+ * DESIGN.md exposes 9 semantic levels (display, h1...h4, body-lg...body-sm,
  * caption); Material 3 has its own 5x3 typography slot grid (display /
  * headline / title / body / label x large/medium/small). Mapping below
  * keeps the visual hierarchy intact while populating every Material slot

--- a/android/app/src/main/java/com/murphyslaws/ui/theme/WorkSans.kt
+++ b/android/app/src/main/java/com/murphyslaws/ui/theme/WorkSans.kt
@@ -11,8 +11,8 @@ import com.murphyslaws.R
  * Work Sans variable-font FontFamily for Compose.
  *
  * Backed by the single TTF at `res/font/work_sans_variable.ttf` (added in
- * PR Android-3). The wght axis lets one TTF cover every weight DESIGN.md
- * uses; we register one Font per weight slot so Compose's typography
+ * PR Android-3). The weight axis lets one TTF cover every weight DESIGN.md
+ * uses; we register one Font per weight slot, so Compose's typography
  * system can resolve `.weight(...)` requests on the family.
  *
  * Variation settings require API 26+, which matches the app's `minSdk`.

--- a/android/app/src/test/java/com/murphyslaws/util/MarkdownParserTest.kt
+++ b/android/app/src/test/java/com/murphyslaws/util/MarkdownParserTest.kt
@@ -24,8 +24,9 @@ class MarkdownParserTest {
         )
 
         val link = annotatedString.getLinkAnnotations(0, annotatedString.length).single()
+        val linkAnnotation = link.item as androidx.compose.ui.text.LinkAnnotation.Clickable
 
         assertEquals("Read docs", annotatedString.text)
-        assertEquals(linkColor, link.item.styles?.style?.color)
+        assertEquals(linkColor.value.toLong(), linkAnnotation.styles?.style?.color?.value?.toLong())
     }
 }

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,4 +1,4 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
+// Top-level build file where you can add configuration options common to all sub-projects / modules.
 
 // Note: AGP 8.13.1 produces warnings about deprecated multi-string dependency notation
 // (com.android.tools.lint:lint-gradle and com.android.tools.build:aapt2).
@@ -6,10 +6,9 @@
 // by Google in a future AGP release before Gradle 10. Safe to ignore.
 
 plugins {
-    id("com.android.application") version "9.2.0" apply false
-    id("org.jetbrains.kotlin.android") version "2.2.21" apply false
-    id("org.jetbrains.kotlin.plugin.compose") version "2.2.21" apply false
-    id("com.google.dagger.hilt.android") version "2.57.2" apply false
+    id("com.android.application") version "9.2.1" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.3.21" apply false
+    id("com.google.dagger.hilt.android") version "2.59.2" apply false
     id("com.google.devtools.ksp") version "2.3.2" apply false
-    id("org.jetbrains.kotlin.plugin.serialization") version "2.2.21" apply false
+    id("org.jetbrains.kotlin.plugin.serialization") version "2.3.21" apply false
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,13 +2,10 @@ android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m
-android.defaults.buildfeatures.resvalues=true
 android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
-android.enableAppCompileTimeRClass=false
-android.usesSdkInManifest.disallowed=false
 android.uniquePackageNames=false
 android.dependency.useConstraints=true
 android.r8.strictFullModeForKeepRules=false
-android.r8.optimizedResourceShrinking=false
-android.builtInKotlin=false
-android.newDsl=false
+android.builtInKotlin=true
+android.newDsl=true
+android.disallowKotlinSourceSets=false

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 pluginManagement {
     repositories {
         google()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murphys-laws-monorepo",
-      "version": "2.5.5",
+      "version": "2.5.6",
       "license": "CC0-1.0",
       "workspaces": [
         "backend",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "description": "Murphy's Laws - Monorepo for Web, iOS, and Android apps",
   "private": true,
   "workspaces": [


### PR DESCRIPTION
## Summary

- Updates the Android build to target SDK 37 with refreshed Gradle, Kotlin, Compose, Hilt, Navigation, serialization, and test dependencies.
- Bumps Android to `1.2.2` / versionCode `9` and root to `2.5.6`, with the changelog entry for the release.

## Test plan

- [x] `./gradlew testDebugUnitTest`
- [x] `npm run check:versions`
- [x] Commit hook validation: backend/web typecheck, lint, tests, coverage, and web E2E

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ravidorr/murphys-laws/124)
<!-- Reviewable:end -->
