### PR TITLE
fix: abort hung API fetches after 10s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- API fetches now abort after 10 seconds via `AbortSignal.timeout`, so a stalled
+  backend fails fast instead of letting Firefox hang for ~60 s. Voting and
+  submission timeouts surface as "The request timed out. Please try again."
+  rather than the generic network error. Web bumped to `3.3.4`; root to `2.5.7`.
 - Law-list cards now use the same elevated card shadow, border, and row padding
   scale as other archive cards, so Browse widgets no longer look visually flatter
   than neighboring card surfaces. Web bumped to `3.3.3`; root to `2.5.4`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murphys-laws-monorepo",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "license": "CC0-1.0",
       "workspaces": [
         "backend",
@@ -16252,7 +16252,7 @@
     },
     "web": {
       "name": "murphys-laws-web",
-      "version": "3.3.3",
+      "version": "3.3.4",
       "license": "CC0-1.0",
       "dependencies": {
         "@sentry/browser": "^10.25.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "description": "Murphy's Laws - Monorepo for Web, iOS, and Android apps",
   "private": true,
   "workspaces": [

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-web",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "description": "Murphy's Laws Web Application",
   "type": "module",
   "scripts": {

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -1,6 +1,6 @@
 // Centralized API utilities
 import * as Sentry from '@sentry/browser';
-import { API_BASE_URL, DEFAULT_FETCH_HEADERS } from './constants.ts';
+import { API_BASE_URL, DEFAULT_FETCH_HEADERS, FETCH_TIMEOUT_MS } from './constants.ts';
 import type { Law, Category, PaginatedResponse, RelatedLawsResponse, ListResponse } from '../types/app.d.ts';
 
 function isFetchTransportError(error: unknown): boolean {
@@ -31,7 +31,10 @@ export async function fetchAPI(endpoint: string, params: URLSearchParams | Recor
   const queryString = qs.toString();
   const url = `${API_BASE_URL}${endpoint}${queryString ? '?' + queryString : ''}`;
 
-  const response = await fetch(url, { headers: DEFAULT_FETCH_HEADERS });
+  const response = await fetch(url, {
+    headers: DEFAULT_FETCH_HEADERS,
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
   if (!response.ok) {
     throw new Error(`API request failed: ${response.status}`);
   }
@@ -61,7 +64,10 @@ export async function fetchLaw(lawId: number | string): Promise<Law> {
   const endpoint = `/api/v1/laws/${numericId}`;
   const url = `${API_BASE_URL}${endpoint}`;
 
-  const response = await fetch(url, { headers: DEFAULT_FETCH_HEADERS });
+  const response = await fetch(url, {
+    headers: DEFAULT_FETCH_HEADERS,
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
   if (!response.ok) {
     throw new Error(`Failed to fetch law: ${response.status}`);
   }

--- a/web/src/utils/constants.ts
+++ b/web/src/utils/constants.ts
@@ -63,6 +63,11 @@ export const DEFAULT_FETCH_HEADERS: Record<string, string> = {
   'Accept': 'application/json'
 };
 
+// Abort fetches that hang past this — browsers can otherwise wait ~60s on a
+// dead connection, which lets duplicate widget fetches pile up across SPA
+// navigations and surfaces as a delayed wave of NetworkErrors.
+export const FETCH_TIMEOUT_MS = 10_000;
+
 // Search autocomplete
 export const SEARCH_AUTOCOMPLETE_DEBOUNCE_DELAY = 240; // ms
 

--- a/web/src/utils/request.ts
+++ b/web/src/utils/request.ts
@@ -1,7 +1,7 @@
 // Generic API request utility with error handling
 // Eliminates ~325 lines of duplicate fetch logic across voting, submissions, etc.
 
-import { API_BASE_URL } from './constants.ts';
+import { API_BASE_URL, FETCH_TIMEOUT_MS } from './constants.ts';
 
 /**
  * Generic API request handler with error handling
@@ -56,9 +56,15 @@ async function fetchWithErrorHandling(url: string, options: RequestInit): Promis
   let response;
 
   try {
-    response = await fetch(url, options);
-  } catch {
-    // Network errors (offline, timeout, etc.)
+    response = await fetch(url, {
+      ...options,
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'TimeoutError') {
+      throw new Error('The request timed out. Please try again.');
+    }
+    // Network errors (offline, etc.)
     throw new Error('Network error. Please check your connection and try again.');
   }
 

--- a/web/tests/api.test.ts
+++ b/web/tests/api.test.ts
@@ -136,6 +136,19 @@ describe('API utilities', () => {
       expect(result).toEqual(mockLaw);
     });
 
+    it('passes an AbortSignal so stalled requests fail fast', async () => {
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({ id: 1 })
+      });
+
+      await fetchLaw(1);
+
+      const callArgs = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(callArgs[1].signal).toBeInstanceOf(AbortSignal);
+    });
+
     it('enters content-type check when headers.get exists and returns empty (covers L57 B1)', async () => {
       const mockLaw = { id: 1, title: 'Test', text: 'Text' };
       fetchSpy.mockResolvedValueOnce({
@@ -476,6 +489,19 @@ describe('API utilities', () => {
 
       expect(fetchSpy).toHaveBeenCalledTimes(1);
       expect(result).toEqual({ data: [{ id: 1 }] });
+    });
+
+    it('passes an AbortSignal so stalled requests fail fast', async () => {
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({ data: [] })
+      });
+
+      await fetchAPI('/api/laws');
+
+      const callArgs = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(callArgs[1].signal).toBeInstanceOf(AbortSignal);
     });
   });
 

--- a/web/tests/request.test.ts
+++ b/web/tests/request.test.ts
@@ -121,6 +121,26 @@ describe('request utilities', () => {
       expect(fetchSpy).toHaveBeenCalledTimes(1);
     });
 
+    it('surfaces AbortSignal.timeout TimeoutError as a friendly timeout message', async () => {
+      const timeoutErr = new DOMException('The operation timed out.', 'TimeoutError');
+      fetchSpy.mockRejectedValue(timeoutErr);
+
+      await expect(apiRequest('/api/test')).rejects.toThrow('The request timed out. Please try again.');
+    });
+
+    it('injects an AbortSignal so stalled requests fail fast', async () => {
+      fetchSpy.mockResolvedValueOnce(asResponse({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true }),
+      }));
+
+      await apiRequest('/api/test');
+
+      const callArgs = fetchSpy.mock.calls[0] as unknown as [string, RequestInit];
+      expect(callArgs[1].signal).toBeInstanceOf(AbortSignal);
+    });
+
     it('throws error when API returns non-ok response', async () => {
       fetchSpy.mockResolvedValueOnce(asResponse({
         ok: false,


### PR DESCRIPTION
## Summary

- `fetchAPI`, `fetchLaw`, and `request.ts`'s `fetchWithErrorHandling` now pass `signal: AbortSignal.timeout(10_000)`, so stalled requests abort after 10 s instead of riding Firefox's ~60 s default
- Voting and submission timeouts surface as `"The request timed out. Please try again."` instead of the generic `"Network error..."`
- Adds tests covering the signal wiring and the new timeout message

## Why

A recent Sentry `TypeError: NetworkError when attempting to fetch resource.` traced back to two consecutive Home mounts (`/about → /` then `/browse → /`) firing duplicate widget fetches that all stalled for ~60 s before failing in a confusing wave. The timeout makes those failures fast and visible. The duplicate-fetch problem itself is a separate follow-up (in-flight de-dup across SPA mounts).

## Versions

- Root `2.5.6 → 2.5.7`
- Web `3.3.3 → 3.3.4`

## Test plan

- [ ] `npm --prefix web run test:coverage` — 99.04% lines / 95.07% branches, 2808 tests pass
- [ ] `npm --prefix web run typecheck && npm --prefix web run lint` clean
- [ ] Manual: with backend stopped, open a page that calls `/api/v1/law-of-day`; the home loads (degraded) within ~10 s instead of hanging
- [ ] Manual: with backend stopped, attempt to vote; toast surfaces `"The request timed out. Please try again."`

## Notes

Pushed with `SKIP_AUDIT=1` after explicit user approval — `npm audit` flags two pre-existing high vulns (`fast-uri` inside `@modelcontextprotocol/sdk`'s `ajv`, `@babel/plugin-transform-modules-systemjs` inside `vite-plugin-pwa`'s `workbox-build`) that neither `npm audit fix`, `--force`, nor nested `overrides` can reach. Both are non-runtime (internal MCP tooling, build-time babel). Should be addressed via upstream-release follow-up.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ravidorr/murphys-laws/125)
<!-- Reviewable:end -->
