### PR TITLE
fix: drop cross-browser fetch transport rejections in Sentry beforeSend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Sentry now drops the three cross-browser fetch transport rejections at
+  `beforeSend` - `Failed to fetch` (Chrome / Edge),
+  `NetworkError when attempting to fetch resource.` (Firefox), and `Load failed`
+  (Safari). These come from disconnected clients (offline mobile, captive
+  portals, dropped cell signal), not application bugs; views like
+  `category-detail.ts` that catch fetch errors and call
+  `Sentry.captureException` were flooding the dashboard with user-connectivity
+  noise. Web bumped to `3.3.6`; root to `2.5.10`.
+
 ### Changed
 - Refreshed `package-lock.json` to clear all 8 outstanding `npm audit`
   advisories (2 high + 6 moderate). `npm update` re-resolved

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.5.9",
+  "version": "2.5.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murphys-laws-monorepo",
-      "version": "2.5.9",
+      "version": "2.5.10",
       "license": "CC0-1.0",
       "workspaces": [
         "backend",
@@ -16237,7 +16237,7 @@
     },
     "web": {
       "name": "murphys-laws-web",
-      "version": "3.3.5",
+      "version": "3.3.6",
       "license": "CC0-1.0",
       "dependencies": {
         "@sentry/browser": "^10.25.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.5.9",
+  "version": "2.5.10",
   "description": "Murphy's Laws - Monorepo for Web, iOS, and Android apps",
   "private": true,
   "workspaces": [

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-web",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "description": "Murphy's Laws Web Application",
   "type": "module",
   "scripts": {

--- a/web/src/utils/sentry-ignore-patterns.ts
+++ b/web/src/utils/sentry-ignore-patterns.ts
@@ -20,6 +20,17 @@ export const SENTRY_IGNORED_ERROR_PATTERNS: RegExp[] = [
   // Android WebView JS-to-Java bridge teardown race on beforeunload (seen in Facebook in-app
   // browser calling its internal enableDidUserTypeOnKeyboardLogging analytics). Not our code.
   /Java object is gone/i,
+  // Fetch transport failures from a disconnected client (offline mobile, captive portal,
+  // DNS hiccup, dropped cell signal). Each major engine uses different phrasing for the
+  // same underlying TypeError that fetch() rejects with:
+  //   Chrome / Edge: "Failed to fetch"
+  //   Firefox:       "NetworkError when attempting to fetch resource."
+  //   Safari:        "Load failed"
+  // These aren't application bugs; views that catch fetch errors and blindly call
+  // Sentry.captureException would otherwise flood the dashboard with user-connectivity noise.
+  /^Failed to fetch$/,
+  /NetworkError when attempting to fetch resource/i,
+  /^Load failed$/,
 ];
 
 /**

--- a/web/tests/sentry-ignore-patterns.test.ts
+++ b/web/tests/sentry-ignore-patterns.test.ts
@@ -28,8 +28,19 @@ describe('sentry-ignore-patterns', () => {
       expect(isSentryErrorIgnored('Non-Error promise rejection captured with value: undefined')).toBe(true);
     });
 
+    it('returns true for cross-browser fetch transport rejections from disconnected clients', () => {
+      // Chrome / Edge
+      expect(isSentryErrorIgnored('Failed to fetch')).toBe(true);
+      // Firefox
+      expect(isSentryErrorIgnored('NetworkError when attempting to fetch resource.')).toBe(true);
+      // Safari
+      expect(isSentryErrorIgnored('Load failed')).toBe(true);
+    });
+
     it('returns false for application errors', () => {
       expect(isSentryErrorIgnored('Cannot read property "x" of undefined')).toBe(false);
+      // Generic-sounding strings that should NOT be swept up by the fetch-transport patterns
+      expect(isSentryErrorIgnored('Failed to fetch laws from upstream cache')).toBe(false);
       expect(isSentryErrorIgnored('Network request failed')).toBe(false);
       expect(isSentryErrorIgnored('Service worker registration failed')).toBe(false);
       expect(isSentryErrorIgnored('Importing a module script failed')).toBe(false);
@@ -38,7 +49,7 @@ describe('sentry-ignore-patterns', () => {
 
   describe('SENTRY_IGNORED_ERROR_PATTERNS', () => {
     it('has the expected number of patterns', () => {
-      expect(SENTRY_IGNORED_ERROR_PATTERNS.length).toBe(9);
+      expect(SENTRY_IGNORED_ERROR_PATTERNS.length).toBe(12);
       expect(SENTRY_IGNORED_ERROR_PATTERNS.some((p) => p.test('chrome-extension://x'))).toBe(true);
     });
   });


### PR DESCRIPTION
## Summary

Sentry reported a `TypeError: Failed to fetch` from `/category/murphys-office-laws` on a Chrome Mobile / Android client in Kigali. The stack traces back to `web/src/views/category-detail.ts:269-271`:

```ts
} catch (error) {
  Sentry.captureException(error);
}
```

`fetchCategoryDetails` calls Sentry on **any** error, so a phone that lost cell signal mid-tap surfaces as an application bug. Similar blanket-catch patterns exist in `categories.ts:117` and several other views.

## Fix

Add the three cross-browser fetch-rejection messages to `SENTRY_IGNORED_ERROR_PATTERNS` so the global `beforeSend` drops them everywhere at once, instead of needing every callsite to remember to filter:

| Engine | Message |
|---|---|
| Chrome / Edge | `Failed to fetch` |
| Firefox | `NetworkError when attempting to fetch resource.` |
| Safari | `Load failed` |

Regexes are anchored (`/^Failed to fetch$/`, `/^Load failed$/`) so legitimate app errors like `"Failed to fetch laws from upstream cache"` aren't swept up. A negative test guards that.

## Why global instead of per-callsite

- Catches every existing site (4+ blanket `catch → captureException` blocks across views) in one change
- Future-proof — new views with blanket catches still get filtered without remembering
- Real app errors (rendering bugs, malformed responses, etc.) still surface

The existing per-callsite filter in `api.ts → fetchSuggestions` (via `isFetchTransportError`) stays as defense-in-depth and because it also handles `DOMException` `AbortError` / `TimeoutError` specifically.

## Versions

- Root `2.5.9 → 2.5.10`
- Web `3.3.5 → 3.3.6`

## Test plan

- [ ] `tests/sentry-ignore-patterns.test.ts` — 8/8 pass, including new positive cases for each browser and a guard against the false-positive `"Failed to fetch laws from upstream cache"`
- [ ] Full pre-commit hook ran cleanly (backend + web `test:coverage`, E2E)
- [ ] Watch Sentry for the `/category/murphys-office-laws` issue to stop receiving new events

## Notes

This is the proper fix for the offline-mobile-user noise the previous PRs only partly addressed (`isFetchTransportError` in `fetchSuggestions` only covered autocomplete).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ravidorr/murphys-laws/128)
<!-- Reviewable:end -->
