### PR TITLE
fix: keep CTA labels on one line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   root to `2.6.0`.
 
 ### Fixed
+- CTA labels now stay on one line, keeping text and icons side by side across
+  desktop and mobile layouts. Web bumped to `3.4.2`; root to `2.6.2`.
 - Pinned iOS CI to the macOS 15 runner that provides Xcode 16.4, and stabilized
   homepage loading so the Daily Law updates inside reserved space without
   shifting the rest of the page. Web bumped to `3.4.1`; root to `2.6.1`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murphys-laws-monorepo",
-      "version": "2.6.1",
+      "version": "2.6.2",
       "license": "CC0-1.0",
       "workspaces": [
         "backend",
@@ -16000,7 +16000,7 @@
     },
     "web": {
       "name": "murphys-laws-web",
-      "version": "3.4.1",
+      "version": "3.4.2",
       "license": "CC0-1.0",
       "dependencies": {
         "@sentry/browser": "^10.25.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Murphy's Laws - Monorepo for Web, iOS, and Android apps",
   "private": true,
   "workspaces": [

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-web",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Murphy's Laws Web Application",
   "type": "module",
   "scripts": {

--- a/web/styles/partials/components.css
+++ b/web/styles/partials/components.css
@@ -17,6 +17,7 @@
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
+  white-space: nowrap;
   box-sizing: border-box;
   transition: background-color .15s ease, border-color .15s ease, filter .15s ease, box-shadow .15s ease;
 }


### PR DESCRIPTION
## Summary

- Keep CTA labels and icons on a single line through the shared button style.
- Bump the root and web patch versions and record the fix in the changelog.

## Validation

- Full pre-commit suite: backend typecheck, lint, database build, 373 backend tests, web typecheck/lint/HTML/CSS checks, 2,854 web tests, full Playwright suite, and coverage checks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ravidorr/murphys-laws/131)
<!-- Reviewable:end -->
