### PR TITLE
fix: keep routes and category slugs canonical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `1.2.3` / build `19`; Android to `1.2.4` / versionCode `11`; root to `2.6.3`.
 
 ### Fixed
+- Legacy calculator URLs now permanently redirect to their canonical calculator pages
+  instead of returning a static 404. Root bumped to `2.6.9`.
 - Archive routes now preserve backend rendering for newly published laws and
   categories, return real 404s for unknown paths, and keep canonical category
   slugs aligned across generated pages, UI links, API documentation, and AI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `1.2.3` / build `19`; Android to `1.2.4` / versionCode `11`; root to `2.6.3`.
 
 ### Fixed
+- Archive routes now preserve backend rendering for newly published laws and
+  categories, return real 404s for unknown paths, and keep canonical category
+  slugs aligned across generated pages, UI links, API documentation, and AI
+  discovery files. Backend bumped to `2.3.2`; web to `3.4.7`; root to `2.6.8`.
 - Dark-mode autocomplete matches now use the highlight foreground token, so
   matched text remains high-contrast on the yellow highlight surface. Web
   bumped to `3.4.6`; root to `2.6.7`.

--- a/backend/db/migrations/017_normalize_category_slugs.sql
+++ b/backend/db/migrations/017_normalize_category_slugs.sql
@@ -1,0 +1,12 @@
+-- Keep the seeded archive and production category URLs aligned. These slugs
+-- were corrected in production but the historical seed migration retained
+-- their old filenames, causing fresh SSG builds to publish stale routes.
+UPDATE categories SET slug = 'murphys-4x4-car-laws' WHERE slug = 'murphys-cars-4x4-laws';
+UPDATE categories SET slug = 'murphys-law-of-the-open-road' WHERE slug = 'murphys-cars-open-road-laws';
+UPDATE categories SET slug = 'murphys-computer-laws' WHERE slug = 'murphys-computers-laws';
+UPDATE categories SET slug = 'murphys-cowboy-action-shooting-cas-laws' WHERE slug = 'murphys-cowboy-action-shooting-laws';
+UPDATE categories SET slug = 'murphys-helicopters-warfare-laws' WHERE slug = 'murphys-helicopters-war-laws';
+UPDATE categories SET slug = 'murphys-marine-corps-laws' WHERE slug = 'murphys-marine-corp-laws';
+UPDATE categories SET slug = 'murphys-laws-of-mechanics' WHERE slug = 'murphys-mechanics-laws';
+UPDATE categories SET slug = 'murphys-repairmans-laws' WHERE slug = 'murphys-repairmen-laws';
+UPDATE categories SET slug = 'murphys-tank-warfare-laws' WHERE slug = 'murphys-tanks-war-laws';

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-backend",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Murphy's Laws API Server",
   "type": "module",
   "main": "src/server/api-server.ts",

--- a/backend/scripts/build-sqlite.ts
+++ b/backend/scripts/build-sqlite.ts
@@ -13,6 +13,21 @@ const ROOT = path.resolve(__dirname, '..');
 const SOURCE_DIR = path.join(ROOT, '../shared/data/murphys-laws');
 const DB_PATH = path.join(ROOT, 'murphys.db');
 
+// The source archive predates the canonical public URLs. Keep fresh database
+// builds aligned with the category slugs served by production and emitted by
+// SSG, while retaining the original source filenames.
+const CATEGORY_SLUG_ALIASES: Record<string, string> = {
+  'murphys-cars-4x4-laws': 'murphys-4x4-car-laws',
+  'murphys-cars-open-road-laws': 'murphys-law-of-the-open-road',
+  'murphys-computers-laws': 'murphys-computer-laws',
+  'murphys-cowboy-action-shooting-laws': 'murphys-cowboy-action-shooting-cas-laws',
+  'murphys-helicopters-war-laws': 'murphys-helicopters-warfare-laws',
+  'murphys-marine-corp-laws': 'murphys-marine-corps-laws',
+  'murphys-mechanics-laws': 'murphys-laws-of-mechanics',
+  'murphys-repairmen-laws': 'murphys-repairmans-laws',
+  'murphys-tanks-war-laws': 'murphys-tank-warfare-laws',
+};
+
 export interface Attribution {
   name: string;
   contact_type: string;
@@ -33,6 +48,10 @@ function slugify(s: string): string {
     .trim()
     .replace(/\s+/g, '-')
     .replace(/-+/g, '-');
+}
+
+export function canonicalCategorySlug(slug: string): string {
+  return CATEGORY_SLUG_ALIASES[slug] ?? slug;
 }
 
 async function listMarkdownFiles(dir: string): Promise<string[]> {
@@ -124,7 +143,7 @@ async function buildSQL(): Promise<string> {
   for (const file of files) {
     const basename = path.basename(file, '.md');
     const rel = path.relative(ROOT, file);
-    const slug = slugify(basename);
+    const slug = canonicalCategorySlug(slugify(basename));
     const content = await fs.readFile(file, 'utf8');
     const contentTimestamp = getStableContentTimestamp(file);
     const lines = content.split('\n');

--- a/backend/tests/parse-attributions.test.ts
+++ b/backend/tests/parse-attributions.test.ts
@@ -1,7 +1,20 @@
 import { describe, it, expect } from 'vitest';
-import { parseAttributions } from '../scripts/build-sqlite.ts';
+import { canonicalCategorySlug, parseAttributions } from '../scripts/build-sqlite.ts';
 
 describe('parseAttributions', () => {
+  it('uses canonical category slugs for renamed archive files', () => {
+    expect(canonicalCategorySlug('murphys-cars-4x4-laws')).toBe('murphys-4x4-car-laws');
+    expect(canonicalCategorySlug('murphys-cars-open-road-laws')).toBe('murphys-law-of-the-open-road');
+    expect(canonicalCategorySlug('murphys-computers-laws')).toBe('murphys-computer-laws');
+    expect(canonicalCategorySlug('murphys-cowboy-action-shooting-laws')).toBe('murphys-cowboy-action-shooting-cas-laws');
+    expect(canonicalCategorySlug('murphys-helicopters-war-laws')).toBe('murphys-helicopters-warfare-laws');
+    expect(canonicalCategorySlug('murphys-marine-corp-laws')).toBe('murphys-marine-corps-laws');
+    expect(canonicalCategorySlug('murphys-mechanics-laws')).toBe('murphys-laws-of-mechanics');
+    expect(canonicalCategorySlug('murphys-repairmen-laws')).toBe('murphys-repairmans-laws');
+    expect(canonicalCategorySlug('murphys-tanks-war-laws')).toBe('murphys-tank-warfare-laws');
+    expect(canonicalCategorySlug('murphys-technology-laws')).toBe('murphys-technology-laws');
+  });
+
   it('parses mailto simple', () => {
     const input = 'The alarm will never go off. Sent by [Brad Johnson](mailto:brad42681@yahoo.com).';
     const res = parseAttributions(input);

--- a/nginx.conf
+++ b/nginx.conf
@@ -45,6 +45,14 @@ server {
         return 301 https://murphys-laws.com/category/murphys-tank-warfare-laws$is_args$args;
     }
 
+    # Preserve direct visits to calculator routes kept by the client router.
+    location = /calculator {
+        return 301 https://murphys-laws.com/calculator/sods-law$is_args$args;
+    }
+    location = /toastcalculator {
+        return 301 https://murphys-laws.com/calculator/buttered-toast$is_args$args;
+    }
+
     # Pre-rendered routes are preferred, but new laws and categories can be
     # published after the last SSG build. Let the API render only those known
     # dynamic route patterns; unrelated paths still reach the static 404.

--- a/nginx.conf
+++ b/nginx.conf
@@ -15,16 +15,76 @@ server {
     # Public application URLs are canonical without a trailing slash.
     rewrite ^/(.+)/$ /$1 permanent;
 
+    # Category slugs were corrected in the API. Preserve their search equity
+    # and avoid serving the SPA's misleading empty-category state.
+    location = /category/murphys-cars-4x4-laws {
+        return 301 https://murphys-laws.com/category/murphys-4x4-car-laws$is_args$args;
+    }
+    location = /category/murphys-cars-open-road-laws {
+        return 301 https://murphys-laws.com/category/murphys-law-of-the-open-road$is_args$args;
+    }
+    location = /category/murphys-computers-laws {
+        return 301 https://murphys-laws.com/category/murphys-computer-laws$is_args$args;
+    }
+    location = /category/murphys-cowboy-action-shooting-laws {
+        return 301 https://murphys-laws.com/category/murphys-cowboy-action-shooting-cas-laws$is_args$args;
+    }
+    location = /category/murphys-helicopters-war-laws {
+        return 301 https://murphys-laws.com/category/murphys-helicopters-warfare-laws$is_args$args;
+    }
+    location = /category/murphys-marine-corp-laws {
+        return 301 https://murphys-laws.com/category/murphys-marine-corps-laws$is_args$args;
+    }
+    location = /category/murphys-mechanics-laws {
+        return 301 https://murphys-laws.com/category/murphys-laws-of-mechanics$is_args$args;
+    }
+    location = /category/murphys-repairmen-laws {
+        return 301 https://murphys-laws.com/category/murphys-repairmans-laws$is_args$args;
+    }
+    location = /category/murphys-tanks-war-laws {
+        return 301 https://murphys-laws.com/category/murphys-tank-warfare-laws$is_args$args;
+    }
+
+    # Pre-rendered routes are preferred, but new laws and categories can be
+    # published after the last SSG build. Let the API render only those known
+    # dynamic route patterns; unrelated paths still reach the static 404.
+    location ~ ^/law/\d+$ {
+        try_files $uri/index.html @law-detail;
+    }
+    location ~ ^/category/[^/]+$ {
+        try_files $uri/index.html @category-detail;
+    }
+
     location / {
         # Serve the pre-rendered route without redirecting to its directory URL.
-        # Unknown routes fall back to the SPA shell so the client router can render 404s.
-        try_files $uri/index.html $uri /index.html;
+        # Unknown routes must return a real 404, not an indexable SPA soft-404.
+        try_files $uri/index.html $uri =404;
         
         # Cache control for static assets
         location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
             expires 1y;
             add_header Cache-Control "public, no-transform";
         }
+    }
+
+    location @law-detail {
+        proxy_pass http://127.0.0.1:8787;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_intercept_errors on;
+    }
+
+    location @category-detail {
+        proxy_pass http://127.0.0.1:8787;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_intercept_errors on;
     }
 
     # Custom 404 page

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.6.8",
+  "version": "2.6.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murphys-laws-monorepo",
-      "version": "2.6.8",
+      "version": "2.6.9",
       "license": "CC0-1.0",
       "workspaces": [
         "backend",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.6.7",
+  "version": "2.6.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murphys-laws-monorepo",
-      "version": "2.6.7",
+      "version": "2.6.8",
       "license": "CC0-1.0",
       "workspaces": [
         "backend",
@@ -31,7 +31,7 @@
     },
     "backend": {
       "name": "murphys-laws-backend",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "license": "CC0-1.0",
       "dependencies": {
         "@sentry/node": "^10.67.0",
@@ -9323,7 +9323,7 @@
     },
     "web": {
       "name": "murphys-laws-web",
-      "version": "3.4.6",
+      "version": "3.4.7",
       "license": "CC0-1.0",
       "dependencies": {
         "@sentry/browser": "^10.25.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.6.7",
+  "version": "2.6.8",
   "description": "Murphy's Laws - Monorepo for Web, iOS, and Android apps",
   "private": true,
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.6.8",
+  "version": "2.6.9",
   "description": "Murphy's Laws - Monorepo for Web, iOS, and Android apps",
   "private": true,
   "workspaces": [

--- a/scripts/smoke-production.mjs
+++ b/scripts/smoke-production.mjs
@@ -36,6 +36,8 @@ async function expectNotFound(route) {
 await expectRedirect('http://murphys-laws.com/browse', `${canonicalOrigin}/browse`);
 await expectRedirect('https://www.murphys-laws.com/browse', `${canonicalOrigin}/browse`);
 await expectRedirect(`${canonicalOrigin}/submit/`, `${canonicalOrigin}/submit`);
+await expectRedirect(`${canonicalOrigin}/calculator`, `${canonicalOrigin}/calculator/sods-law`);
+await expectRedirect(`${canonicalOrigin}/toastcalculator`, `${canonicalOrigin}/calculator/buttered-toast`);
 await expectRedirect(`${canonicalOrigin}/category/murphys-computers-laws`, `${canonicalOrigin}/category/murphys-computer-laws`);
 await expectRedirect(`${canonicalOrigin}/category/murphys-cars-4x4-laws`, `${canonicalOrigin}/category/murphys-4x4-car-laws`);
 await expectRedirect(`${canonicalOrigin}/category/murphys-cars-open-road-laws`, `${canonicalOrigin}/category/murphys-law-of-the-open-road`);

--- a/scripts/smoke-production.mjs
+++ b/scripts/smoke-production.mjs
@@ -25,9 +25,26 @@ async function expectPage(route, { forbidMailto = false } = {}) {
   if (forbidMailto) assert(!/mailto:/i.test(html), `${url}: exposes a contributor email link`);
 }
 
+async function expectNotFound(route) {
+  const url = `${canonicalOrigin}${route}`;
+  const response = await fetchResponse(url);
+  assert(response.status === 404, `${url}: expected 404, received ${response.status}`);
+  const html = await response.text();
+  assert(/<meta name="robots" content="noindex">/i.test(html), `${url}: 404 page must be noindex`);
+}
+
 await expectRedirect('http://murphys-laws.com/browse', `${canonicalOrigin}/browse`);
 await expectRedirect('https://www.murphys-laws.com/browse', `${canonicalOrigin}/browse`);
 await expectRedirect(`${canonicalOrigin}/submit/`, `${canonicalOrigin}/submit`);
+await expectRedirect(`${canonicalOrigin}/category/murphys-computers-laws`, `${canonicalOrigin}/category/murphys-computer-laws`);
+await expectRedirect(`${canonicalOrigin}/category/murphys-cars-4x4-laws`, `${canonicalOrigin}/category/murphys-4x4-car-laws`);
+await expectRedirect(`${canonicalOrigin}/category/murphys-cars-open-road-laws`, `${canonicalOrigin}/category/murphys-law-of-the-open-road`);
+await expectRedirect(`${canonicalOrigin}/category/murphys-cowboy-action-shooting-laws`, `${canonicalOrigin}/category/murphys-cowboy-action-shooting-cas-laws`);
+await expectRedirect(`${canonicalOrigin}/category/murphys-helicopters-war-laws`, `${canonicalOrigin}/category/murphys-helicopters-warfare-laws`);
+await expectRedirect(`${canonicalOrigin}/category/murphys-marine-corp-laws`, `${canonicalOrigin}/category/murphys-marine-corps-laws`);
+await expectRedirect(`${canonicalOrigin}/category/murphys-mechanics-laws`, `${canonicalOrigin}/category/murphys-laws-of-mechanics`);
+await expectRedirect(`${canonicalOrigin}/category/murphys-repairmen-laws`, `${canonicalOrigin}/category/murphys-repairmans-laws`);
+await expectRedirect(`${canonicalOrigin}/category/murphys-tanks-war-laws`, `${canonicalOrigin}/category/murphys-tank-warfare-laws`);
 
 await expectPage('/browse');
 await expectPage('/categories');
@@ -35,6 +52,7 @@ await expectPage('/submit');
 await expectPage('/calculator/sods-law');
 await expectPage('/category/murphys-technology-laws', { forbidMailto: true });
 await expectPage('/law/1354', { forbidMailto: true });
+await expectNotFound('/definitely-not-a-real-page');
 
 const api = await fetchResponse(`${canonicalOrigin}/api/v1/laws?limit=1`);
 assert(api.ok, `API smoke check failed with ${api.status}`);

--- a/shared/docs/API.md
+++ b/shared/docs/API.md
@@ -647,7 +647,7 @@ Get related category suggestions for internal linking and topic discovery.
       "description": "Tech truths: to err is human, to really foul things up requires a computer."
     }
   ],
-  "category_slug": "murphys-computers-laws"
+  "category_slug": "murphys-computer-laws"
 }
 ```
 

--- a/web/e2e/accessibility.spec.ts
+++ b/web/e2e/accessibility.spec.ts
@@ -104,7 +104,7 @@ test.describe('Accessibility - WCAG AA Compliance', () => {
   const auditedRoutes = [
     '/',
     '/browse',
-    '/category/murphys-computers-laws',
+    '/category/murphys-computer-laws',
     '/law/2',
     '/submit',
     '/favorites',

--- a/web/e2e/qa-regressions.spec.ts
+++ b/web/e2e/qa-regressions.spec.ts
@@ -72,7 +72,7 @@ test.describe('QA regressions', () => {
       if (message.type() === 'error') consoleErrors.push(message.text());
     });
 
-    await page.goto('/category/murphys-computers-laws');
+    await page.goto('/category/murphys-computer-laws');
     await expect(page.locator('main h1')).toBeVisible({ timeout: 10000 });
     await expect(page.locator('.law-card-mini').first()).toBeVisible({ timeout: 10000 });
     await page.waitForLoadState('networkidle');
@@ -100,7 +100,7 @@ test.describe('QA regressions', () => {
 
   for (const route of [
     '/browse',
-    '/category/murphys-computers-laws',
+    '/category/murphys-computer-laws',
     '/law/2',
     '/submit',
     '/calculator/sods-law',

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-web",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "description": "Murphy's Laws Web Application",
   "type": "module",
   "scripts": {

--- a/web/public/llms-full.txt
+++ b/web/public/llms-full.txt
@@ -126,7 +126,7 @@ Example response:
 ```json
 [
   {"id": 1, "slug": "murphys-laws", "title": "Murphy's Laws", "description": "The foundational laws...", "law_count": 228},
-  {"id": 2, "slug": "murphys-computers-laws", "title": "Murphy's Computer Laws", "description": "Digital doom...", "law_count": 182}
+  {"id": 2, "slug": "murphys-computer-laws", "title": "Murphy's Computer Laws", "description": "Digital doom...", "law_count": 161}
 ]
 ```
 
@@ -176,27 +176,27 @@ Machine-readable API definition.
 
 Complete list of category slugs for use with the `category_slug` parameter:
 
-murphys-laws, murphys-love-laws, murphys-war-laws, murphys-computers-laws,
+murphys-laws, murphys-love-laws, murphys-war-laws, murphys-computer-laws,
 murphys-miscellaneous-laws, murphys-technology-laws, murphys-commerce-laws,
 murphys-music-laws, murphys-teaching-laws, murphys-emt-laws,
-murphys-cowboy-action-shooting-laws, murphys-nurses-laws,
+murphys-cowboy-action-shooting-cas-laws, murphys-nurses-laws,
 murphys-photography-laws, murphys-military-police-laws,
 murphys-employees-laws, murphys-cops-laws, murphys-office-laws,
 murphys-volunteer-bushfire-brigade-laws, murphys-toddlers-laws,
-murphys-bus-laws, murphys-cars-laws, murphys-cars-open-road-laws,
+murphys-bus-laws, murphys-cars-laws, murphys-law-of-the-open-road,
 murphys-graphic-design-laws, murphys-jagged-alliance-2-laws,
 murphys-sewing-laws, murphys-horse-laws, murphys-college-student-laws,
-murphys-cars-4x4-laws, murphys-real-estate-laws,
+murphys-4x4-car-laws, murphys-real-estate-laws,
 murphys-transformers-laws, murphys-game-mastering-laws,
 murphys-lotto-laws, murphys-fighting-airplanes-laws,
 murphys-martial-arts-laws, murphys-travel-laws, murphys-golf-laws,
 murphys-political-laws, murphys-role-playing-by-internet-message-board-laws,
 murphys-desert-war-laws, murphys-mothers-laws,
 murphys-unformatted-character-sheets-laws, murphys-alarm-clock-laws,
-murphys-mechanics-laws, murphys-scouting-laws, murphys-tv-laws,
+murphys-laws-of-mechanics, murphys-scouting-laws, murphys-tv-laws,
 murphys-elevator-laws, murphys-printing-laws, murphys-microbiology-laws,
-murphys-rental-laws, murphys-tanks-war-laws, murphys-helicopters-war-laws,
-murphys-sport-laws, murphys-repairmen-laws, murphys-marine-corp-laws,
+murphys-rental-laws, murphys-tank-warfare-laws, murphys-helicopters-warfare-laws,
+murphys-sport-laws, murphys-repairmans-laws, murphys-marine-corps-laws,
 murphys-gravity-laws
 
 ## Content Pages

--- a/web/scripts/ssg.ts
+++ b/web/scripts/ssg.ts
@@ -31,6 +31,22 @@ interface Law {
   };
 }
 
+interface Category {
+  slug: string;
+  title: string;
+  law_count: number;
+}
+
+interface CategoryListResponse {
+  data: Category[];
+}
+
+type FetchCategoriesRequest = (url: string) => Promise<{
+  ok: boolean;
+  status: number;
+  json(): Promise<unknown>;
+}>;
+
 interface ContentPageMeta {
   slug: string;
   file: string;
@@ -53,7 +69,6 @@ interface ContentMetadataEntry {
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const DIST_DIR = path.resolve(__dirname, '../dist');
-const SHARED_DATA_DIR = path.resolve(__dirname, '../../shared/data/murphys-laws');
 const SHARED_CONTENT_DIR = path.resolve(__dirname, '../../shared/content');
 
 async function readContentMetadata(): Promise<Record<string, ContentMetadataEntry>> {
@@ -217,6 +232,44 @@ async function fetchAllLaws(): Promise<Law[]> {
     console.warn(`Warning: Could not fetch laws from API: ${message}`);
     return [];
   }
+}
+
+/**
+ * Fetch the category source of truth used by the API and application.  SSG
+ * must not derive public routes from archived source filenames: those can
+ * outlive a renamed category and create empty, indexable landing pages.
+ */
+async function fetchAllCategories(fetchRequest: FetchCategoriesRequest = fetch): Promise<Category[]> {
+  const response = await fetchRequest(`${API_BASE_URL}/api/v1/categories`);
+  if (!response.ok) {
+    throw new Error(`Category API returned ${response.status}`);
+  }
+
+  const payload = await response.json() as Partial<CategoryListResponse>;
+  if (!Array.isArray(payload.data) || payload.data.length === 0) {
+    throw new Error('Category API returned no categories; refusing to generate an incomplete sitemap.');
+  }
+
+  const slugs = new Set<string>();
+  return payload.data.map((category, index) => {
+    const slug = typeof category.slug === 'string' ? category.slug.trim() : '';
+    const title = typeof category.title === 'string' ? category.title.trim() : '';
+    const lawCount = Number(category.law_count);
+
+    if (!slug || !title || !Number.isInteger(lawCount) || lawCount < 0) {
+      throw new Error(`Invalid category at API index ${index}.`);
+    }
+    if (slugs.has(slug)) {
+      throw new Error(`Category API returned duplicate slug "${slug}".`);
+    }
+    slugs.add(slug);
+
+    return { slug, title, law_count: lawCount };
+  });
+}
+
+function categorySitemapPaths(categories: Category[]): string[] {
+  return categories.map(({ slug }) => `/category/${slug}`);
 }
 
 async function mergeReviewedLawDetails(laws: Law[]): Promise<Law[]> {
@@ -900,28 +953,11 @@ async function main(): Promise<void> {
   if (laws.length === 0) {
     throw new Error('SSG requires a populated laws API; refusing to generate empty archive pages.');
   }
+  const categories = await fetchAllCategories();
 
   // 1. Generate Category Pages
   console.log('Generating category pages...');
-  const files = await fs.readdir(SHARED_DATA_DIR);
-  const mdFiles = files.filter(f => f.endsWith('.md'));
-
-  const categories = [];
-
-  for (const file of mdFiles) {
-    const slug = file.replace('.md', '');
-    const content = await fs.readFile(path.join(SHARED_DATA_DIR, file), 'utf-8');
-    
-    // Parse Markdown
-    const tokens = marked.lexer(content);
-    const titleToken = tokens.find((t): t is import('marked').Tokens.Heading => t.type === 'heading' && t.depth === 1);
-    const title = titleToken && 'text' in titleToken ? titleToken.text : slug.replace(/-/g, ' ');
-    
-    // Count laws (list items)
-    const law_count = (content.match(/^\s*\*/gm) || []).length;
-
-    // Collect category info for the Browse page
-    categories.push({ slug, title, law_count });
+  for (const { slug, title, law_count } of categories) {
 
     // Output directory: dist/category/[slug]/
     const outDir = path.join(DIST_DIR, 'category', slug);
@@ -991,7 +1027,7 @@ async function main(): Promise<void> {
     await fs.writeFile(path.join(outDir, 'index.html'), pageHtml);
     // console.log(`Generated category/${slug}/index.html`);
   }
-  console.log(`Generated ${mdFiles.length} category pages.`);
+  console.log(`Generated ${categories.length} category pages.`);
 
   // 2. Generate Browse Page (first page of laws pre-rendered for SEO and no-JS)
   console.log('Generating browse page...');
@@ -1377,10 +1413,10 @@ ${cardHtml.trim()}
   }
 
   // Add category routes
-  for (const cat of categories) {
+  for (const categoryPath of categorySitemapPaths(categories)) {
     sitemap += `
   <url>
-    <loc>${baseUrl}/category/${cat.slug}</loc>
+    <loc>${baseUrl}${categoryPath}</loc>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>`;
@@ -1484,5 +1520,7 @@ export {
   buildStaticCalculatorContent,
   buildStaticLawDetailContent,
   applyPageMetadata,
-  validateGeneratedPage
+  validateGeneratedPage,
+  fetchAllCategories,
+  categorySitemapPaths
 };

--- a/web/src/components/templates/header.html
+++ b/web/src/components/templates/header.html
@@ -59,7 +59,7 @@
     <div class="header-actions flex items-center gap-2">
       <form role="search" class="header-search flex items-center gap-2" aria-label="Site Search">
         <input type="text" id="header-search" name="search" aria-label="Search" placeholder="Search laws..." class="input">
-        <button type="submit" class="btn">
+        <button type="submit" class="btn" aria-label="Search">
           <span class="icon" data-icon="search" aria-hidden="true"></span>
           <span class="btn-text">Search</span>
         </button>

--- a/web/src/types/ssg.d.ts
+++ b/web/src/types/ssg.d.ts
@@ -37,6 +37,12 @@ declare module '@scripts/ssg' {
     image?: string;
   }
 
+  export interface StaticCategory {
+    slug: string;
+    title: string;
+    law_count: number;
+  }
+
   export const CONTENT_PAGES: ContentPageMeta[];
   export function wrapFirstWordWithAccent(text: string): string;
   export function enhanceMarkdownHtml(html: string): string;
@@ -52,4 +58,10 @@ declare module '@scripts/ssg' {
   }): string[];
   export function buildStaticLawDetailContent(law: StaticLaw, related?: StaticLaw[]): string;
   export function buildStaticHomeContent(): string;
+  export function fetchAllCategories(fetchRequest?: (url: string) => Promise<{
+    ok: boolean;
+    status: number;
+    json(): Promise<unknown>;
+  }>): Promise<StaticCategory[]>;
+  export function categorySitemapPaths(categories: StaticCategory[]): string[];
 }

--- a/web/src/utils/constants.ts
+++ b/web/src/utils/constants.ts
@@ -15,8 +15,8 @@ export const SITE_NAME = "Murphy's Law Archive";
 
 /** Editorial display-name overrides for category slugs (cleaner titles without changing URLs) */
 export const CATEGORY_DISPLAY_NAME_OVERRIDES: Record<string, string> = {
-  'murphys-cars-4x4-laws': "Murphy's 4x4 & Off-Road Laws",
-  'murphys-helicopters-war-laws': "Murphy's Helicopter & Warfare Laws",
+  'murphys-4x4-car-laws': "Murphy's 4x4 & Off-Road Laws",
+  'murphys-helicopters-warfare-laws': "Murphy's Helicopter & Warfare Laws",
   'murphys-unformatted-character-sheets-laws': "Murphy's RPG Character Sheet Laws",
 };
 

--- a/web/src/utils/internal-links.ts
+++ b/web/src/utils/internal-links.ts
@@ -23,7 +23,7 @@ const CATEGORY_LINKS: Record<string, InternalLink[]> = {
     { href: '/examples/tech', label: 'Technology examples', description: 'Real situations where tech goes sideways.' },
     { href: '/calculator/sods-law', label: "Sod's Law Calculator", description: 'Model task risk with urgency and complexity.' },
   ],
-  'murphys-computers-laws': [
+  'murphys-computer-laws': [
     { href: '/murphys-laws-about-technology', label: 'Technology hub', description: 'Software, hardware, and system failures.' },
     { href: '/examples/tech', label: 'Technology examples', description: 'Common tech scenarios with linked laws.' },
     { href: '/category/murphys-technology-laws', label: 'Related technology laws', description: 'A broader technical category.' },

--- a/web/src/views/categories.ts
+++ b/web/src/views/categories.ts
@@ -24,7 +24,7 @@ export function Categories({ onNavigate }: { onNavigate: OnNavigate }): HTMLDivE
     'murphys-office-laws',
     'murphys-travel-laws',
     'murphys-love-laws',
-    'murphys-computers-laws'
+    'murphys-computer-laws'
   ]);
 
   // Render a single category card

--- a/web/src/views/favorites.ts
+++ b/web/src/views/favorites.ts
@@ -88,7 +88,7 @@ export function Favorites({ onNavigate }: { onNavigate: OnNavigate }): HTMLDivEl
           <div class="not-found-categories mt-8">
             <p class="small text-muted-fg mb-4">Or explore popular categories:</p>
             <div class="not-found-category-links">
-              <button type="button" class="btn outline" data-nav="category" data-param="murphys-computers-laws">Computer Laws</button>
+              <button type="button" class="btn outline" data-nav="category" data-param="murphys-computer-laws">Computer Laws</button>
               <button type="button" class="btn outline" data-nav="category" data-param="murphys-love-laws">Love Laws</button>
               <button type="button" class="btn outline" data-nav="category" data-param="murphys-technology-laws">Technology Laws</button>
             </div>

--- a/web/src/views/templates/not-found.html
+++ b/web/src/views/templates/not-found.html
@@ -31,7 +31,7 @@
     <div class="not-found-categories mt-8">
       <p class="small text-muted-fg mb-4">Or explore popular categories:</p>
       <div class="not-found-category-links">
-        <button type="button" class="btn outline" data-nav="category" data-param="murphys-computers-laws">Computer Laws</button>
+        <button type="button" class="btn outline" data-nav="category" data-param="murphys-computer-laws">Computer Laws</button>
         <button type="button" class="btn outline" data-nav="category" data-param="murphys-love-laws">Love Laws</button>
         <button type="button" class="btn outline" data-nav="category" data-param="murphys-technology-laws">Technology Laws</button>
       </div>

--- a/web/tests/categories.test.ts
+++ b/web/tests/categories.test.ts
@@ -47,7 +47,7 @@ describe('Categories view', () => {
       data: [
         { 
           id: 1, 
-          slug: 'murphys-computers-laws',
+          slug: 'murphys-computer-laws',
           title: "Murphy's Computer Laws", 
           description: 'Digital doom: programs are obsolete when running.',
           law_count: 163
@@ -223,21 +223,21 @@ describe('Categories view', () => {
   it('L139 B1: click on category card triggers onNavigate with slug', async () => {
     const el = Categories({ onNavigate: localThis.onNavigate });
     await new Promise(resolve => setTimeout(resolve, 10));
-    const card = el.querySelector('.category-card[data-category-slug="murphys-computers-laws"]');
+    const card = el.querySelector('.category-card[data-category-slug="murphys-computer-laws"]');
     expect(card).toBeTruthy();
     (card as HTMLElement)!.click();
-    expect(localThis.onNavigate).toHaveBeenCalledWith('category', 'murphys-computers-laws');
+    expect(localThis.onNavigate).toHaveBeenCalledWith('category', 'murphys-computer-laws');
   });
 
   it('navigates to category on card click', async () => {
     const el = Categories({ onNavigate: localThis.onNavigate });
     await new Promise(resolve => setTimeout(resolve, 10));
 
-    const card = el.querySelector('.category-card[data-category-slug="murphys-computers-laws"]');
+    const card = el.querySelector('.category-card[data-category-slug="murphys-computer-laws"]');
     expect(card).toBeTruthy();
     
     (card as HTMLElement)!.click();
-    expect(localThis.onNavigate).toHaveBeenCalledWith('category', 'murphys-computers-laws');
+    expect(localThis.onNavigate).toHaveBeenCalledWith('category', 'murphys-computer-laws');
   });
 
   it('L149 B1: keydown on category card enters card branch', async () => {

--- a/web/tests/category-groups.test.ts
+++ b/web/tests/category-groups.test.ts
@@ -8,7 +8,7 @@ describe('category groups', () => {
 
   it('groups known category slugs into editorial clusters', () => {
     const groups = groupCategories([
-      { slug: 'murphys-computers-laws', title: "Murphy's Computer Laws" },
+      { slug: 'murphys-computer-laws', title: "Murphy's Computer Laws" },
       { slug: 'murphys-office-laws', title: "Murphy's Office Laws" },
       { slug: 'murphys-travel-laws', title: "Murphy's Travel Laws" },
       { slug: 'murphys-love-laws', title: "Murphy's Love Laws" },

--- a/web/tests/category-slug-docs.test.ts
+++ b/web/tests/category-slug-docs.test.ts
@@ -1,0 +1,49 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = path.resolve(__dirname, '../..');
+const canonicalCategorySlugs = [
+  'murphys-4x4-car-laws',
+  'murphys-law-of-the-open-road',
+  'murphys-computer-laws',
+  'murphys-cowboy-action-shooting-cas-laws',
+  'murphys-helicopters-warfare-laws',
+  'murphys-marine-corps-laws',
+  'murphys-laws-of-mechanics',
+  'murphys-repairmans-laws',
+  'murphys-tank-warfare-laws',
+];
+const legacyCategorySlugs = [
+  'murphys-cars-4x4-laws',
+  'murphys-cars-open-road-laws',
+  'murphys-computers-laws',
+  'murphys-cowboy-action-shooting-laws',
+  'murphys-helicopters-war-laws',
+  'murphys-marine-corp-laws',
+  'murphys-mechanics-laws',
+  'murphys-repairmen-laws',
+  'murphys-tanks-war-laws',
+];
+
+describe('category slug documentation', () => {
+  it('publishes only canonical category_slug values', () => {
+    const documents = [
+      path.join(repositoryRoot, 'web/public/llms-full.txt'),
+      path.join(repositoryRoot, 'shared/docs/API.md'),
+    ].map((file) => fs.readFileSync(file, 'utf8'));
+
+    for (const document of documents) {
+      for (const slug of legacyCategorySlugs) {
+        expect(document).not.toContain(slug);
+      }
+    }
+
+    const llmsFull = documents[0]!;
+    for (const slug of canonicalCategorySlugs) {
+      expect(llmsFull).toContain(slug);
+    }
+  });
+});

--- a/web/tests/constants.test.ts
+++ b/web/tests/constants.test.ts
@@ -281,7 +281,7 @@ describe('Constants', () => {
 
   describe('getCategoryDisplayName', () => {
     it('returns override when slug is in CATEGORY_DISPLAY_NAME_OVERRIDES', () => {
-      const slug = 'murphys-cars-4x4-laws';
+      const slug = 'murphys-4x4-car-laws';
       const result = getCategoryDisplayName(slug, "Murphy's 4X4 Car Laws Section");
       expect(result).toBe(CATEGORY_DISPLAY_NAME_OVERRIDES[slug]);
       expect(result).toBe("Murphy's 4x4 & Off-Road Laws");

--- a/web/tests/favorites-view.test.ts
+++ b/web/tests/favorites-view.test.ts
@@ -142,7 +142,7 @@ describe('Favorites View Component', () => {
 
       expect(categoriesSection).toBeTruthy();
       expect(categoryLinks.length).toBe(3);
-      expect(categoryLinks[0]!.getAttribute('data-param')).toBe('murphys-computers-laws');
+      expect(categoryLinks[0]!.getAttribute('data-param')).toBe('murphys-computer-laws');
       expect(categoryLinks[1]!.getAttribute('data-param')).toBe('murphys-love-laws');
       expect(categoryLinks[2]!.getAttribute('data-param')).toBe('murphys-technology-laws');
     });
@@ -314,8 +314,8 @@ describe('Favorites View Component', () => {
 
     it('L265 B1: nav link with data-param passes param to onNavigate', () => {
       const el = Favorites({ onNavigate: localThis.mockNavigate });
-      (el.querySelector('[data-param="murphys-computers-laws"]') as HTMLElement).click();
-      expect(localThis.mockNavigate).toHaveBeenCalledWith('category', 'murphys-computers-laws');
+      (el.querySelector('[data-param="murphys-computer-laws"]') as HTMLElement).click();
+      expect(localThis.mockNavigate).toHaveBeenCalledWith('category', 'murphys-computer-laws');
     });
 
     it('L273 B1: keydown on law card with lawId calls onNavigate', () => {
@@ -341,11 +341,11 @@ describe('Favorites View Component', () => {
 
     it('navigates to category with param when category link is clicked', () => {
       const el = Favorites({ onNavigate: localThis.mockNavigate });
-      const categoryLink = el.querySelector('[data-param="murphys-computers-laws"]') as HTMLElement | null;
+      const categoryLink = el.querySelector('[data-param="murphys-computer-laws"]') as HTMLElement | null;
 
       categoryLink?.click();
 
-      expect(vi.mocked(localThis.mockNavigate)).toHaveBeenCalledWith('category', 'murphys-computers-laws');
+      expect(vi.mocked(localThis.mockNavigate)).toHaveBeenCalledWith('category', 'murphys-computer-laws');
     });
 
     it('navigates to law detail when law card is clicked', () => {

--- a/web/tests/header.test.ts
+++ b/web/tests/header.test.ts
@@ -125,6 +125,17 @@ describe('Header component', () => {
     document.body.removeChild(el);
   });
 
+  it('keeps an accessible name on the header search button when its text is hidden on mobile', () => {
+    const el = Header({
+      onSearch: () => {},
+      onNavigate: () => {},
+      currentPage: 'home'
+    });
+
+    const submit = el.querySelector('.header-search button[type="submit"]');
+    expect(submit?.getAttribute('aria-label')).toBe('Search');
+  });
+
   it('has navigation menu toggle', () => {
     const el = Header({
       onSearch: () => {},

--- a/web/tests/not-found.test.ts
+++ b/web/tests/not-found.test.ts
@@ -197,5 +197,6 @@ describe('NotFound view', () => {
 
     const categoryLinks = el.querySelectorAll('.not-found-category-links button');
     expect(categoryLinks.length).toBeGreaterThan(0);
+    expect(categoryLinks[0]?.getAttribute('data-param')).toBe('murphys-computer-laws');
   });
 });

--- a/web/tests/ssg.test.ts
+++ b/web/tests/ssg.test.ts
@@ -10,7 +10,9 @@ import {
   buildStaticLawDetailContent,
   buildStaticHomeContent,
   applyPageMetadata,
-  validateGeneratedPage
+  validateGeneratedPage,
+  fetchAllCategories,
+  categorySitemapPaths
 } from '@scripts/ssg';
 
 const metadataTemplate = `<!doctype html><html><head>
@@ -206,6 +208,27 @@ describe('SSG Utilities', () => {
 });
 
 describe('SSG Static Route Content', () => {
+  it('uses the category API as the sitemap source of truth', async () => {
+    const fetchRequest = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [
+          { slug: 'murphys-computer-laws', title: "Murphy's Computer Laws", law_count: 161 },
+          { slug: 'murphys-law-of-the-open-road', title: "Murphy's Law of the Open Road", law_count: 20 }
+        ]
+      })
+    });
+
+    const categories = await fetchAllCategories(fetchRequest);
+
+    expect(categorySitemapPaths(categories)).toEqual([
+      '/category/murphys-computer-laws',
+      '/category/murphys-law-of-the-open-road'
+    ]);
+    expect(categorySitemapPaths(categories)).not.toContain('/category/murphys-computers-laws');
+  });
+
   it('includes developers as a generated content page', () => {
     expect(CONTENT_PAGES.map((page) => page.slug)).toContain('developers');
   });


### PR DESCRIPTION
## Summary

- Return real 404s without breaking dynamic law and category deep links published after SSG.
- Canonicalize renamed category slugs across database builds, SSG, UI navigation, sitemap, API docs, and AI discovery files.
- Fix the mobile header search accessible name and add production smoke/regression coverage.

## Validation

- `npm run check:versions`
- `npm run build:web`
- `npm --prefix web run test:e2e -- qa-regressions.spec.ts accessibility.spec.ts`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ravidorr/murphys-laws/133)
<!-- Reviewable:end -->
