### PR TITLE
fix(web): fit buttered toast formula

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `1.2.3` / build `19`; Android to `1.2.4` / versionCode `11`; root to `2.6.3`.
 
 ### Fixed
+- Buttered Toast calculator formulas now scale to the available card width without horizontal scrolling.
 - Legacy calculator URLs now permanently redirect to their canonical calculator pages
   instead of returning a static 404. Root bumped to `2.6.9`.
 - Archive routes now preserve backend rendering for newly published laws and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `1.2.3` / build `19`; Android to `1.2.4` / versionCode `11`; root to `2.6.3`.
 
 ### Fixed
-- Buttered Toast calculator formulas now scale to the available card width without horizontal scrolling.
+- Buttered Toast calculator formulas now scale to the available card width without horizontal scrolling. Web
+  bumped to `3.4.8`; root to `2.6.10`.
 - Legacy calculator URLs now permanently redirect to their canonical calculator pages
   instead of returning a static 404. Root bumped to `2.6.9`.
 - Archive routes now preserve backend rendering for newly published laws and

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.6.9",
+  "version": "2.6.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murphys-laws-monorepo",
-      "version": "2.6.9",
+      "version": "2.6.10",
       "license": "CC0-1.0",
       "workspaces": [
         "backend",
@@ -9323,7 +9323,7 @@
     },
     "web": {
       "name": "murphys-laws-web",
-      "version": "3.4.7",
+      "version": "3.4.8",
       "license": "CC0-1.0",
       "dependencies": {
         "@sentry/browser": "^10.25.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-monorepo",
-  "version": "2.6.9",
+  "version": "2.6.10",
   "description": "Murphy's Laws - Monorepo for Web, iOS, and Android apps",
   "private": true,
   "workspaces": [

--- a/web/e2e/qa-regressions.spec.ts
+++ b/web/e2e/qa-regressions.spec.ts
@@ -48,6 +48,23 @@ test.describe('QA regressions', () => {
     });
   }
 
+  for (const viewport of [
+    { name: 'mobile', width: 320, height: 640 },
+    { name: 'desktop', width: 1440, height: 900 },
+  ]) {
+    test(`buttered toast formula fits at ${viewport.name} width`, async ({ page }) => {
+      await page.setViewportSize(viewport);
+      await page.goto('/calculator/buttered-toast');
+
+      const formula = page.locator('#toast-formula-display');
+      await expect(formula.locator('math')).toBeVisible();
+      await expect(formula).toHaveAttribute('aria-label', 'Buttered toast probability formula');
+
+      expect(await formula.evaluate(element => element.scrollWidth <= element.clientWidth)).toBe(true);
+      expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
+    });
+  }
+
   test('homepage search keeps the query in the URL, form, and results', async ({ page }) => {
     await page.goto('/');
     const homeSearch = page.locator('[data-home-zone="archive-search"] input[type="search"]');

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murphys-laws-web",
-  "version": "3.4.7",
+  "version": "3.4.8",
   "description": "Murphy's Laws Web Application",
   "type": "module",
   "scripts": {

--- a/web/styles/partials/calculator.css
+++ b/web/styles/partials/calculator.css
@@ -182,6 +182,16 @@
   padding: 0 var(--space-4);
 }
 
+/* The toast expression is longer than the shared calculator formulas. */
+#toast-formula-display {
+  container-type: inline-size;
+  overflow-x: hidden;
+}
+
+#toast-formula-display math {
+  font-size: min(var(--text-5xl), 2.7cqw) !important;
+}
+
 /* Responsive formula sizing */
 @media (width <= 768px) {
   .formula {


### PR DESCRIPTION
## Summary

- Scale the Buttered Toast MathML formula to its available card width.
- Prevent horizontal scrolling without changing shared or native formulas.
- Add mobile and desktop overflow regression coverage.

## Validation

- `npm --prefix web run lint:css`
- `npm --prefix web run typecheck`
- `npm --prefix web test -- tests/buttered-toast-calculator.test.ts`
- Targeted formula E2E: 2 passed at 320px and 1440px
- Full E2E: 46 passed; one existing navigation test flaked in parallel but passed on isolated retry.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ravidorr/murphys-laws/134)
<!-- Reviewable:end -->
